### PR TITLE
Data vault swap

### DIFF
--- a/src/app/DataVault/DataVaultComponent.tsx
+++ b/src/app/DataVault/DataVaultComponent.tsx
@@ -9,15 +9,20 @@ interface DataVaultComponentProps {
   declarativeDetails: DataVaultKey
   addDeclarativeDetail: (client: DataVaultWebClient, key: string, content: string) => any
   deleteValue: (client: DataVaultWebClient, key: string, id: string) => any
+  swapValue: (client: DataVaultWebClient, key: string, content: string, id: string) => any
 }
 
-const DataVaultComponent: React.FC<DataVaultComponentProps> = ({ addDeclarativeDetail, declarativeDetails, deleteValue }) => {
+const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
+  addDeclarativeDetail, declarativeDetails, deleteValue, swapValue
+}) => {
   const context = useContext(Web3ProviderContext)
 
   const handleAdd = (key: string, content: string) =>
     context.dvClient && addDeclarativeDetail(context.dvClient, key, content)
   const handleDelete = (key: string, id: string) =>
     context.dvClient && deleteValue(context.dvClient, key, id)
+  const handleSwap = (key: string, content: string, id: string) =>
+    context.dvClient && swapValue(context.dvClient, key, content, id)
 
   return (
     <div className="content data-vault">
@@ -30,7 +35,9 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({ addDeclarativeD
         <div className="column">
           <DeclarativeDetailsDisplay
             details={declarativeDetails}
-            deleteValue={handleDelete} />
+            deleteValue={handleDelete}
+            swapValue={handleSwap}
+          />
         </div>
       </div>
     </div>

--- a/src/app/DataVault/DataVaultContainer.ts
+++ b/src/app/DataVault/DataVaultContainer.ts
@@ -4,7 +4,7 @@ import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 import { stateInterface } from '../state/configureStore'
 import DataVaultComponent from './DataVaultComponent'
 import { AnyAction } from 'redux'
-import { createDataVaultContent, deleteDataVaultContent } from '../state/operations/datavault'
+import { createDataVaultContent, deleteDataVaultContent, swapDataVaultContent } from '../state/operations/datavault'
 
 const mapStateToProps = (state: stateInterface) => ({
   declarativeDetails: state.datavault.data
@@ -14,7 +14,9 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<stateInterface, {}, AnyActio
   addDeclarativeDetail: (client: DataVaultWebClient, key: string, content: string) =>
     dispatch(createDataVaultContent(client, key, content)),
   deleteValue: (client: DataVaultWebClient, key: string, id: string) =>
-    dispatch(deleteDataVaultContent(client, key, id))
+    dispatch(deleteDataVaultContent(client, key, id)),
+  swapValue: (client: DataVaultWebClient, key: string, content: string, id: string) =>
+    dispatch(swapDataVaultContent(client, key, content, id))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(DataVaultComponent)

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
 import DeclarativeDetailsDisplay from './DeclarativeDetailsDisplay'
 import { DataVaultKey } from '../../state/reducers/datavault'
 
@@ -9,13 +10,18 @@ describe('Component: DeclarativeDetailsDisplay', () => {
     NAME: [{ id: '5', content: 'Jesse Clark' }]
   }
 
+  const mockedAttributes = {
+    deleteValue: jest.fn(),
+    swapValue: jest.fn()
+  }
+
   it('renders the component', () => {
-    const wrapper = shallow(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} deleteValue={jest.fn()} />)
+    const wrapper = shallow(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} {...mockedAttributes} />)
     expect(wrapper).toBeDefined()
   })
 
   it('shows the content in a row', () => {
-    const wrapper = shallow(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} deleteValue={jest.fn()} />)
+    const wrapper = shallow(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} {...mockedAttributes} />)
     expect(wrapper.find('tbody').children()).toHaveLength(2)
 
     expect(wrapper.find('tr').at(1).find('td').at(0).text()).toBe('EMAIL')
@@ -28,16 +34,46 @@ describe('Component: DeclarativeDetailsDisplay', () => {
       NAME: []
     }
 
-    const wrapper = shallow(<DeclarativeDetailsDisplay details={mockDetails} deleteValue={jest.fn()} />)
+    const wrapper = shallow(<DeclarativeDetailsDisplay details={mockDetails} {...mockedAttributes} />)
     expect(wrapper.find('tbody').children()).toHaveLength(1)
   })
 
-  it('handles delete click', () => {
-    const deleteValue = jest.fn()
-    const wrapper = mount(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} deleteValue={deleteValue} />)
+  it('handles delete click', async () => {
+    const deleteFunction = jest.fn()
+    const deleteValue = (key: string, id: string) => new Promise((resolve) => resolve(deleteFunction(key, id)))
+    const wrapper = mount(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} deleteValue={deleteValue} swapValue={jest.fn()} />)
 
-    wrapper.find('.content-row').at(0).find('button').simulate('click')
-    wrapper.find('.delete-modal').find('.column').at(1).find('button').simulate('click')
-    expect(deleteValue).toBeCalledWith('EMAIL', '1')
+    wrapper.find('.content-row').at(0).find('button.delete').simulate('click')
+
+    await act(async () => {
+      await wrapper.find('.delete-modal').find('.column').at(1).find('button').simulate('click')
+
+      expect(deleteFunction).toBeCalledTimes(1)
+      expect(deleteFunction).toBeCalledWith('EMAIL', '1')
+    })
+  })
+
+  it('handles swap click', async () => {
+    const editFunction = jest.fn()
+    const swapValue = (key:string, content: string, id: string) => new Promise((resolve) => resolve(editFunction(key, content, id)))
+    const wrapper = mount(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} deleteValue={jest.fn()} swapValue={swapValue} />)
+
+    wrapper.find('.content-row').at(0).find('button.edit').simulate('click')
+    expect(wrapper.find('textarea').props().value).toBe('jesse@iovlabs.org')
+
+    await act(async () => {
+      await wrapper.find('.edit-modal').find('button.submit').simulate('click')
+      wrapper.update()
+      expect(wrapper.find('.modal-content').find('div.alert.error').text()).toBe('New value is the same as the old.')
+
+      wrapper.find('textarea.line').simulate('change', { target: { value: 'new@value.org' } })
+      expect(wrapper.find('textarea').props().value).toBe('new@value.org')
+
+      await wrapper.find('.edit-modal').find('button.submit').simulate('click')
+      wrapper.update()
+
+      expect(editFunction).toBeCalledTimes(1)
+      expect(editFunction).toBeCalledWith('EMAIL', 'new@value.org', '1')
+    })
   })
 })

--- a/src/app/state/operations/datavault.ts
+++ b/src/app/state/operations/datavault.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from 'react'
 import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 import { createDidFormat } from '../../../formatters'
-import { addContentToKey, DataVaultContent, receiveKeyData, removeContentfromKey } from '../reducers/datavault'
+import { addContentToKey, DataVaultContent, receiveKeyData, removeContentfromKey, swapContentById } from '../reducers/datavault'
 import { getDataVault } from '../../../config/getConfig'
 import { CreateContentResponse } from '@rsksmart/ipfs-cpinner-client/lib/types'
 
@@ -59,3 +59,7 @@ export const createDataVaultContent = (client: DataVaultWebClient, key: string, 
 export const deleteDataVaultContent = (client: DataVaultWebClient, key: string, id: string) => (dispatch: Dispatch<any>) =>
   client.delete({ key, id })
     .then(() => dispatch(removeContentfromKey({ key, id })))
+
+export const swapDataVaultContent = (client: DataVaultWebClient, key: string, content: string, id: string) => (dispatch: Dispatch<any>) =>
+  client.swap({ key, content, id })
+    .then(() => dispatch(swapContentById({ key, id, content })))

--- a/src/app/state/reducers/datavault.test.ts
+++ b/src/app/state/reducers/datavault.test.ts
@@ -1,5 +1,5 @@
 import { configureStore, Store, AnyAction } from '@reduxjs/toolkit'
-import dataVaultSlice, { DataVaultState, receiveKeyData, initialState, addContentToKey, removeContentfromKey, swapContentById, DataVaultKey, DataVaultContent } from './datavault'
+import dataVaultSlice, { DataVaultState, receiveKeyData, initialState, addContentToKey, removeContentfromKey, swapContentById, DataVaultContent } from './datavault'
 
 describe('dataVault slice', () => {
   describe('action creators', () => {
@@ -7,6 +7,20 @@ describe('dataVault slice', () => {
       const content = [{ id: '1', content: 'hello' }]
       expect(receiveKeyData({ key: 'KEY', content }))
         .toEqual({ type: receiveKeyData.type, payload: { key: 'KEY', content } })
+    })
+
+    test('addContentToKey', () => {
+      const content = { key: 'KEY', content: { id: '1', content: 'hello' } }
+      expect(addContentToKey(content)).toEqual({ type: addContentToKey.type, payload: content })
+    })
+
+    test('removeContentfromKey', () => {
+      expect(removeContentfromKey({ key: 'KEY', id: '2' })).toEqual({ type: removeContentfromKey.type, payload: { key: 'KEY', id: '2' } })
+    })
+
+    test('swapContentById', () => {
+      const content = { key: 'KEY', id: '2', content: 'new' }
+      expect(swapContentById(content)).toEqual({ type: swapContentById.type, payload: content })
     })
   })
 

--- a/src/app/state/reducers/datavault.test.ts
+++ b/src/app/state/reducers/datavault.test.ts
@@ -1,5 +1,5 @@
 import { configureStore, Store, AnyAction } from '@reduxjs/toolkit'
-import dataVaultSlice, { DataVaultState, receiveKeyData, initialState, addContentToKey, removeContentfromKey } from './datavault'
+import dataVaultSlice, { DataVaultState, receiveKeyData, initialState, addContentToKey, removeContentfromKey, swapContentById, DataVaultKey, DataVaultContent } from './datavault'
 
 describe('dataVault slice', () => {
   describe('action creators', () => {
@@ -74,6 +74,26 @@ describe('dataVault slice', () => {
         store.dispatch(removeContentfromKey({ key: 'MY_KEY', id: '2' }))
 
         expect(store.getState().data).toEqual({ MY_KEY: [] })
+      })
+    })
+
+    describe('swapContentById', () => {
+      const initContent = [{ id: '1', content: 'hello' }, { id: '2', content: 'hello' }]
+
+      beforeEach(() => {
+        store.dispatch(receiveKeyData({ key: 'MY_KEY', content: initContent }))
+      })
+
+      test('it swaps content of existing key', () => {
+        store.dispatch(swapContentById({ id: '1', content: 'newContent', key: 'MY_KEY' }))
+
+        const id1 = store.getState().data.MY_KEY.filter((item: DataVaultContent) => item.id === '1')[0]
+        expect(id1.content).toBe('newContent')
+      })
+
+      test('it keeps content when id is invalid', () => {
+        store.dispatch(swapContentById({ id: '15', content: 'newContent', key: 'MY_KEY' }))
+        expect(store.getState().data.MY_KEY).toMatchObject(initContent)
       })
     })
   })

--- a/src/app/state/reducers/datavault.ts
+++ b/src/app/state/reducers/datavault.ts
@@ -14,6 +14,12 @@ interface ReceivePayLoad {
   content: DataVaultContent[]
 }
 
+interface SwapPayLoad {
+  key: string,
+  id: string,
+  content: string
+}
+
 export interface DataVaultState {
   data: DataVaultKey
 }
@@ -34,10 +40,13 @@ const dataVaultSlice = createSlice({
     },
     removeContentfromKey (state: DataVaultState, { payload: { key, id } }: PayloadAction<{ key: string, id: string }>) {
       state.data[key] = state.data[key].filter((item: DataVaultContent) => item.id !== id)
+    },
+    swapContentById (state: DataVaultState, { payload: { key, id, content } }: PayloadAction<SwapPayLoad>) {
+      state.data[key] = state.data[key].map((item: DataVaultContent) => item.id === id ? { ...item, content } : item)
     }
   }
 })
 
-export const { receiveKeyData, addContentToKey, removeContentfromKey } = dataVaultSlice.actions
+export const { receiveKeyData, addContentToKey, removeContentfromKey, swapContentById } = dataVaultSlice.actions
 
 export default dataVaultSlice.reducer

--- a/src/assets/images/icons/pencil.svg
+++ b/src/assets/images/icons/pencil.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1 11.5L11.5 1L15 4.5L4.5 15H1V11.5Z" stroke="#47C4E1"/>
+</svg>

--- a/src/assets/scss/screens/_data-vault.scss
+++ b/src/assets/scss/screens/_data-vault.scss
@@ -55,6 +55,21 @@
         flex: 1;
       }
     }
+
+    .edit-modal {
+      label {
+        display: block;
+        font-weight: bold;
+        padding-bottom: 5px;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 35px;
+        border: 1px solid $lightGray;
+        padding: 5px;
+      }
+    }
   }
 }
 

--- a/src/components/Modal/EditValueModal.test.tsx
+++ b/src/components/Modal/EditValueModal.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import EditValueModal from './EditValueModal'
+
+describe('Component: EditValueModal.test', () => {
+  it('renders the component', () => {
+    const wrapper = mount(<EditValueModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('handles events', () => {
+    const onClose = jest.fn()
+    const onConfirm = jest.fn()
+    const wrapper = mount(<EditValueModal show={true} onConfirm={onConfirm} onClose={onClose} />)
+
+    wrapper.find('button.submit').simulate('click')
+    expect(onConfirm).toBeCalledTimes(1)
+
+    wrapper.find('button.close').simulate('click')
+    expect(onClose).toBeCalledTimes(1)
+  })
+
+  it('starts with initial value for input', () => {
+    const wrapper = mount(<EditValueModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} initValue="hello" />)
+    expect(wrapper.find('input.line').props().value).toBe('hello')
+  })
+
+  it('starts with initial value for textarea', () => {
+    const wrapper = mount(<EditValueModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} initValue="textarea hello" inputType="textarea" />)
+    expect(wrapper.find('textarea.line').text()).toBe('textarea hello')
+  })
+
+  it('returns with new value', () => {
+    const onConfirm = jest.fn()
+    const wrapper = mount(<EditValueModal show={true} onConfirm={onConfirm} onClose={jest.fn()} />)
+
+    wrapper.find('input.editable').simulate('change', { target: { value: 'new value' } })
+    wrapper.find('button.submit').simulate('click')
+    expect(onConfirm).toBeCalledWith('new value')
+  })
+
+  it('handles custom text string', () => {
+    const strings = {
+      title: 'title text',
+      intro: 'intro text',
+      label: 'label text',
+      placeholder: 'placeholder text',
+      submit: 'submit text'
+    }
+
+    const wrapper = mount(<EditValueModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} strings={strings} />)
+
+    expect(wrapper.find('.modal-title').at(0).text()).toBe('title text')
+    expect(wrapper.find('p.intro-text').text()).toBe('intro text')
+    expect(wrapper.find('label').text()).toBe('label text')
+    expect(wrapper.find('input.editable').props().placeholder).toBe('placeholder text')
+    expect(wrapper.find('button.submit').text()).toBe('submit text')
+  })
+
+  it('shows an error message', () => {
+    const wrapper = mount(<EditValueModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} error="An Error Happened!" />)
+    expect(wrapper.find('div.alert').text()).toBe('An Error Happened!')
+  })
+
+  it('disables the inputs when disabled', () => {
+    const wrapper = mount(<EditValueModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} disabled={true} />)
+    expect(wrapper.find('input.editable').props().disabled).toBeTruthy()
+    expect(wrapper.find('button.submit').props().disabled).toBeTruthy()
+  })
+
+  it('displays a textarea instead of input', () => {
+    const wrapper = mount(<EditValueModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} inputType='textarea' />)
+    expect(wrapper.find('.editable').type()).toBe('textarea')
+  })
+})

--- a/src/components/Modal/EditValueModal.tsx
+++ b/src/components/Modal/EditValueModal.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react'
+import { BaseButton } from '../Buttons'
+import Modal from './Modal'
+
+interface EditValueModalInterface {
+  show: boolean
+  className?: string
+  onConfirm: (value: string) => void
+  onClose: () => void
+  disabled?: boolean
+  error?: string | null
+  initValue?: string
+  inputType?: 'input' | 'textarea'
+  strings?: {
+    title?: string,
+    intro?: string,
+    label?: string,
+    placeholder?: string,
+    submit?: string,
+  }
+}
+
+const EditValueModal: React.FC<EditValueModalInterface> = ({
+  show, className, onConfirm, onClose, disabled, error, initValue, inputType, strings
+}) => {
+  const [editable, setEditable] = useState<string>('')
+  const sharedProps = {
+    onChange: (evt: { target: { value: React.SetStateAction<string> } }) => setEditable(evt.target.value as string),
+    disabled,
+    className: 'editable line',
+    placeholder: strings?.placeholder,
+    value: editable || ''
+  }
+
+  useEffect(() => {
+    setEditable(initValue || '')
+  }, [initValue])
+
+  return (
+    <Modal show={show} className={className} onClose={onClose} title={strings?.title || 'Edit Value'}>
+      <p className="intro-text">{strings?.intro}</p>
+      <p>
+        <label>{strings?.label || 'Value:'}</label>
+        {inputType === 'textarea'
+          ? <textarea {...sharedProps} />
+          : <input type="text" {...sharedProps} />}
+      </p>
+      <p>
+        <BaseButton
+          onClick={() => onConfirm(editable)}
+          disabled={disabled}
+          className="submit"
+        >{strings?.submit || 'Submit'}</BaseButton>
+      </p>
+      {error && (
+        <div className="error container">
+          <div className="alert error">{error}</div>
+        </div>
+      )}
+    </Modal>
+  )
+}
+
+export default EditValueModal

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -22,4 +22,9 @@ describe('Component: Modal', () => {
 
     expect(wrapper.props().className).toBe('my-modal')
   })
+
+  it('displays an optional title', () => {
+    const wrapper = mount(<Modal show={true} onClose={jest.fn()} title="My Modal">Hello Modal</Modal>)
+    expect(wrapper.find('.modal-title').at(0).text()).toBe('My Modal')
+  })
 })

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -80,9 +80,9 @@ const Modal: React.FC<PanelInterface> = ({ children, show, title, className, onC
     ? (
       <ModalLightbox show={show} className={className}>
         <ModalBody>
-          <ModalTitle>
+          <ModalTitle className="modal-title">
             {title}
-            <ModalCloseButton onClick={onClose} />
+            <ModalCloseButton className="close" onClick={onClose} />
           </ModalTitle>
           <ModalContent className="modal-content">
             {children}


### PR DESCRIPTION
Updates:

- Lets a user update values in their data vault.
- Adds a new component, `EditValueModal` that can be used to edit a single value. 

In the future, the EthrDid controller and owner modals should be updated to use this component. If this PR is merged, I'll add the issues.
