### PR TITLE
Implement Lazy loading of content inside of keys

### DIFF
--- a/src/app/DataVault/DataVaultComponent.tsx
+++ b/src/app/DataVault/DataVaultComponent.tsx
@@ -14,10 +14,11 @@ interface DataVaultComponentProps {
   deleteValue: (client: DataVaultWebClient, key: string, id: string) => any
   swapValue: (client: DataVaultWebClient, key: string, content: string, id: string) => any
   downloadBackup: (client: DataVaultWebClient) => any
+  getKeyContent: (client: DataVaultWebClient, key: string) => any
 }
 
 const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
-  addDeclarativeDetail, declarativeDetails, credentials, deleteValue, swapValue, downloadBackup
+  addDeclarativeDetail, declarativeDetails, credentials, deleteValue, swapValue, downloadBackup, getKeyContent
 }) => {
   const context = useContext(Web3ProviderContext)
 
@@ -28,6 +29,8 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
   const handleSwap = (key: string, content: string, id: string) =>
     context.dvClient && swapValue(context.dvClient, key, content, id)
   const handleDownload = () => context.dvClient && downloadBackup(context.dvClient)
+  const handleGetKeyContent = (key: string) =>
+    context.dvClient && getKeyContent(context.dvClient, key)
 
   return (
     <div className="content data-vault">
@@ -42,6 +45,7 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
             details={declarativeDetails}
             deleteValue={handleDelete}
             swapValue={handleSwap}
+            getKeyContent={handleGetKeyContent}
           />
         </div>
       </div>

--- a/src/app/DataVault/DataVaultComponent.tsx
+++ b/src/app/DataVault/DataVaultComponent.tsx
@@ -54,6 +54,7 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
           <CredentialDisplay
             credentials={credentials}
             deleteValue={handleDelete}
+            getKeyContent={handleGetKeyContent}
           />
         </div>
       </div>

--- a/src/app/DataVault/DataVaultContainer.ts
+++ b/src/app/DataVault/DataVaultContainer.ts
@@ -4,7 +4,7 @@ import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 import { stateInterface } from '../state/configureStore'
 import DataVaultComponent from './DataVaultComponent'
 import { AnyAction } from 'redux'
-import { createDataVaultContent, deleteDataVaultContent, swapDataVaultContent, downloadBackup } from '../state/operations/datavault'
+import { createDataVaultContent, deleteDataVaultContent, swapDataVaultContent, downloadBackup, getDataVaultContent } from '../state/operations/datavault'
 
 const mapStateToProps = (state: stateInterface) => ({
   declarativeDetails: state.datavault.declarativeDetails,
@@ -18,7 +18,9 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<stateInterface, {}, AnyActio
     dispatch(deleteDataVaultContent(client, key, id)),
   swapValue: (client: DataVaultWebClient, key: string, content: string, id: string) =>
     dispatch(swapDataVaultContent(client, key, content, id)),
-  downloadBackup: (client: DataVaultWebClient) => downloadBackup(client)
+  downloadBackup: (client: DataVaultWebClient) => downloadBackup(client),
+  getKeyContent: (client: DataVaultWebClient, key: string) =>
+    dispatch(getDataVaultContent(client, key))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(DataVaultComponent)

--- a/src/app/DataVault/components/DecryptKey.test.tsx
+++ b/src/app/DataVault/components/DecryptKey.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import DecryptKey from './DecryptKey'
+
+describe('Component: DecryptKey', () => {
+  it('renders the component', () => {
+    const wrapper = mount(<DecryptKey handleGetContent={jest.fn()} disabled={false} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('handles click', () => {
+    const getContent = jest.fn()
+    const wrapper = mount(<DecryptKey handleGetContent={getContent} disabled={false} />)
+    wrapper.find('button').simulate('click')
+    expect(getContent).toBeCalledTimes(1)
+  })
+
+  it('is disabled', () => {
+    const wrapper = mount(<DecryptKey handleGetContent={jest.fn()} disabled={true} />)
+    expect(wrapper.find('button').props().disabled).toBeTruthy()
+  })
+})

--- a/src/app/DataVault/components/DecryptKey.tsx
+++ b/src/app/DataVault/components/DecryptKey.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { BaseButton } from '../../../components/Buttons'
+
+interface DecryptKeyInterface {
+  handleGetContent: () => void
+  disabled: boolean
+}
+
+const DecryptKey: React.FC<DecryptKeyInterface> = ({
+  handleGetContent, disabled
+}) => {
+  return (
+    <div className="decrypt">
+      <BaseButton
+        className="gray small"
+        onClick={handleGetContent}
+        disabled={disabled}>
+        Download
+      </BaseButton>
+    </div>
+  )
+}
+
+export default DecryptKey

--- a/src/app/DataVault/panels/CredentialDisplay.tsx
+++ b/src/app/DataVault/panels/CredentialDisplay.tsx
@@ -1,16 +1,26 @@
-import React from 'react'
+import React, { useState } from 'react'
 import CredentialView from '../../../components/CredentialView/CredentialView'
 import Panel from '../../../components/Panel/Panel'
 import { DataVaultContent, DataVaultKey } from '../../state/reducers/datavault'
 import CredentialIcon from '../../../assets/images/icons/credential.svg'
+import DecryptKey from '../components/DecryptKey'
 import DeleteDvContentButton from '../components/DeleteDvContentButton'
 
 interface CredentialDisplayInterface {
   credentials: DataVaultKey
+  getKeyContent: (key: string) => Promise<any>
   deleteValue: (key: string, id: string) => Promise<any>
 }
 
-const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, deleteValue }) => {
+const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, getKeyContent, deleteValue }) => {
+  const [isGettingContent, setIsGettingContent] = useState<string[]>([])
+  const handleGetContent = (key: string) => {
+    setIsGettingContent([...isGettingContent, key])
+    getKeyContent(key)
+      .catch((err: Error) => console.log(err.message))
+      .finally(() => setIsGettingContent(isGettingContent.filter((k: string) => k !== key)))
+  }
+
   return (
     <Panel title={<><img src={CredentialIcon} /> Credentials</>} className="display credentials">
       <table>
@@ -35,6 +45,9 @@ const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, 
                         />
                       </li>)}
                   </ul>
+                  {credentials[key].length === 0 && (
+                    <DecryptKey handleGetContent={() => handleGetContent(key)} disabled={isGettingContent.includes(key)} />
+                  )}
                 </td>
               </tr>
             )

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
@@ -90,4 +90,12 @@ describe('Component: DeclarativeDetailsDisplay', () => {
       expect(getFunction).toBeCalledTimes(1)
     })
   })
+
+  it('shows a message to download when there are keys with no content', () => {
+    const wrapper = mount(<DeclarativeDetailsDisplay details={{ EMAIL: [] }} {...mockedAttributes} />)
+    expect(wrapper.find('p.intro')).toBeTruthy()
+
+    const wrapper2 = mount(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} {...mockedAttributes} />)
+    expect(wrapper2.contains('p.intro')).toBe(false)
+  })
 })

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
@@ -48,9 +48,24 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
       })
   }
 
+  const showDownloadMessage = () => {
+    const keys = Object.keys(details)
+    if (keys.length === 0) {
+      return false
+    }
+
+    let hasEmpty = false
+    for (var key in details) {
+      if (details[key].length === 0) {
+        hasEmpty = true
+      }
+    }
+    return hasEmpty
+  }
+
   return (
     <Panel title={<><img src={declarativeIcon} /> Declarative Details</>} className="display">
-      {Object.keys(details).length !== 0 && <p className="intro">Click on the download button to decrypt the content. Your wallet will request to decrypt each piece of content.</p>}
+      {showDownloadMessage() && <p className="intro">Click on the download button to decrypt the content. Your wallet will request to decrypt each piece of content.</p>}
       <table>
         <thead>
           <tr>
@@ -69,7 +84,7 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
                   )}
                   {details[key].map((item: DataVaultContent) => (
                     <div className="content-row" key={item.id}>
-                      <div className="content">
+                      <div className="content break-all">
                         <p>{item.content}</p>
                       </div>
                       <div className="options">

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
@@ -5,19 +5,23 @@ import pencilIcon from '../../../assets/images/icons/pencil.svg'
 import { DataVaultContent, DataVaultKey } from '../../state/reducers/datavault'
 import EditValueModal from '../../../components/Modal/EditValueModal'
 import DeleteDvContentButton from '../components/DeleteDvContentButton'
+import { BaseButton } from '../../../components/Buttons'
 
 interface DeclarativeDetailsDisplayInterface {
   deleteValue: (key: string, id: string) => Promise<any>
   swapValue: (key: string, content: string, id: string) => Promise<any>
+  getKeyContent: (key: string) => Promise<any>
   details: DataVaultKey
 }
 
-const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = ({ details, deleteValue, swapValue }) => {
+const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = ({ details, deleteValue, swapValue, getKeyContent }) => {
   interface EditItemI { key: string; item: DataVaultContent }
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [isError, setIsError] = useState<null | string>(null)
   const [isEditing, setIsEditing] = useState<null | EditItemI>(null)
+  const [isGettingContent, setIsGettingContent] = useState<string[]>([])
+  const [isGetError, setIsGetError] = useState<null | string>(null)
 
   const handleEditItem = (newValue: string, existingItem: EditItemI) => {
     if (newValue === existingItem.item.content) {
@@ -36,8 +40,22 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
       .finally(() => setIsLoading(false))
   }
 
+  const handleGetContent = (key: string) => {
+    setIsGetError(null)
+    setIsLoading(true)
+    setIsGettingContent([...isGettingContent, key])
+    getKeyContent(key)
+      .catch((err: Error) => setIsGetError(err.message))
+      .finally(() => {
+        setIsLoading(false)
+        setIsGettingContent(isGettingContent.filter((k: string) => k !== key))
+      })
+  }
+
   return (
     <Panel title={<><img src={declarativeIcon} /> Declarative Details</>} className="display">
+      {Object.keys(details).length !== 0 && <p className="intro">Click on the download button to decrypt the content. Your wallet will request to decrypt each piece of content.</p>}
+      {isGetError && <div className="alert error">{isGetError}</div>}
       <table>
         <thead>
           <tr>
@@ -47,32 +65,40 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
         </thead>
         <tbody>
           { Object.keys(details).map((key: string) => {
-            if (details[key].length !== 0) {
-              return (
-                <tr key={key}>
-                  <td>{key.replace('DD_', '')}</td>
-                  <td>
-                    {details[key].map((item: DataVaultContent) => (
-                      <div className="content-row" key={item.id}>
-                        <div className="content">
-                          <p>{item.content}</p>
-                        </div>
-                        <div className="options">
-                          <button
-                            disabled={isLoading}
-                            className="icon edit"
-                            onClick={() => { setIsError(null); setIsEditing({ key, item }) }}
-                          >
-                            <img src={pencilIcon} alt="Edit item" />
-                          </button>
-                          <DeleteDvContentButton itemKey={key} item={item} deleteValue={deleteValue} />
-                        </div>
+            return (
+              <tr key={key}>
+                <td>{key.replace('DD_', '')}</td>
+                <td>
+                  {details[key].length === 0 && (
+                    <div className="decrypt">
+                      <BaseButton
+                        className="gray small"
+                        onClick={() => handleGetContent(key)}
+                        disabled={isGettingContent.includes(key)}>
+                        Download
+                      </BaseButton>
+                    </div>
+                  )}
+                  {details[key].map((item: DataVaultContent) => (
+                    <div className="content-row" key={item.id}>
+                      <div className="content">
+                        <p>{item.content}</p>
                       </div>
-                    ))}
-                  </td>
-                </tr>
-              )
-            }
+                      <div className="options">
+                        <button
+                          disabled={isLoading}
+                          className="icon edit"
+                          onClick={() => { setIsError(null); setIsEditing({ key, item }) }}
+                        >
+                          <img src={pencilIcon} alt="Edit item" />
+                        </button>
+                        <DeleteDvContentButton itemKey={key} item={item} deleteValue={deleteValue} />
+                      </div>
+                    </div>
+                  ))}
+                </td>
+              </tr>
+            )
           }
           )}
         </tbody>

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
@@ -5,7 +5,7 @@ import pencilIcon from '../../../assets/images/icons/pencil.svg'
 import { DataVaultContent, DataVaultKey } from '../../state/reducers/datavault'
 import EditValueModal from '../../../components/Modal/EditValueModal'
 import DeleteDvContentButton from '../components/DeleteDvContentButton'
-import { BaseButton } from '../../../components/Buttons'
+import DecryptKey from '../components/DecryptKey'
 
 interface DeclarativeDetailsDisplayInterface {
   deleteValue: (key: string, id: string) => Promise<any>
@@ -21,7 +21,6 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
   const [isError, setIsError] = useState<null | string>(null)
   const [isEditing, setIsEditing] = useState<null | EditItemI>(null)
   const [isGettingContent, setIsGettingContent] = useState<string[]>([])
-  const [isGetError, setIsGetError] = useState<null | string>(null)
 
   const handleEditItem = (newValue: string, existingItem: EditItemI) => {
     if (newValue === existingItem.item.content) {
@@ -41,13 +40,10 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
   }
 
   const handleGetContent = (key: string) => {
-    setIsGetError(null)
-    setIsLoading(true)
     setIsGettingContent([...isGettingContent, key])
     getKeyContent(key)
-      .catch((err: Error) => setIsGetError(err.message))
+      .catch((err: Error) => console.log(err))
       .finally(() => {
-        setIsLoading(false)
         setIsGettingContent(isGettingContent.filter((k: string) => k !== key))
       })
   }
@@ -55,7 +51,6 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
   return (
     <Panel title={<><img src={declarativeIcon} /> Declarative Details</>} className="display">
       {Object.keys(details).length !== 0 && <p className="intro">Click on the download button to decrypt the content. Your wallet will request to decrypt each piece of content.</p>}
-      {isGetError && <div className="alert error">{isGetError}</div>}
       <table>
         <thead>
           <tr>
@@ -70,14 +65,7 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
                 <td>{key.replace('DD_', '')}</td>
                 <td>
                   {details[key].length === 0 && (
-                    <div className="decrypt">
-                      <BaseButton
-                        className="gray small"
-                        onClick={() => handleGetContent(key)}
-                        disabled={isGettingContent.includes(key)}>
-                        Download
-                      </BaseButton>
-                    </div>
+                    <DecryptKey handleGetContent={() => handleGetContent(key)} disabled={isGettingContent.includes(key)} />
                   )}
                   {details[key].map((item: DataVaultContent) => (
                     <div className="content-row" key={item.id}>

--- a/src/app/state/reducers/datavault.test.ts
+++ b/src/app/state/reducers/datavault.test.ts
@@ -103,7 +103,7 @@ describe('dataVault slice', () => {
         expect(store.getState().declarativeDetails).toEqual({ MY_KEY: [{ id: '1', content: 'hello' }] })
       })
 
-      test('it deletes multiple items', () => {
+      test('it deletes the key if there is no content left', () => {
         store.dispatch(removeContentfromKey({ key: 'MY_KEY', id: '1' }))
         store.dispatch(removeContentfromKey({ key: 'MY_KEY', id: '2' }))
 

--- a/src/app/state/reducers/datavault.test.ts
+++ b/src/app/state/reducers/datavault.test.ts
@@ -1,5 +1,5 @@
 import { configureStore, Store, AnyAction } from '@reduxjs/toolkit'
-import dataVaultSlice, { DataVaultState, receiveKeyData, initialState, addContentToKey, removeContentfromKey, swapContentById, DataVaultContent, receiveStorageInformation } from './datavault'
+import dataVaultSlice, { DataVaultState, receiveKeyData, initialState, addContentToKey, removeContentfromKey, swapContentById, DataVaultContent, receiveStorageInformation, receiveKeys } from './datavault'
 
 describe('dataVault slice', () => {
   describe('action creators', () => {
@@ -26,6 +26,11 @@ describe('dataVault slice', () => {
     test('receiveStorageInformation', () => {
       const storage = { used: 150, available: 200 }
       expect(receiveStorageInformation({ storage })).toEqual({ type: receiveStorageInformation.type, payload: { storage } })
+    })
+
+    test('receiveKeys', () => {
+      const keys = ['ONE', 'TWO']
+      expect(receiveKeys({ keys })).toEqual({ type: receiveKeys.type, payload: { keys } })
     })
   })
 
@@ -138,6 +143,22 @@ describe('dataVault slice', () => {
       test('it receives storage information', () => {
         store.dispatch(receiveStorageInformation({ storage: { used: 10, available: 15 } }))
         expect(store.getState().storage).toMatchObject({ used: 10, available: 15 })
+      })
+    })
+
+    describe('receiveKeys', () => {
+      test('it receives keys', () => {
+        store.dispatch(receiveKeys({ keys: ['oneDD', 'twoCredential'] }))
+
+        expect(store.getState()).toEqual({
+          credentials: {
+            twoCredential: []
+          },
+          declarativeDetails: {
+            oneDD: []
+          },
+          storage: undefined
+        })
       })
     })
   })

--- a/src/app/state/reducers/datavault.ts
+++ b/src/app/state/reducers/datavault.ts
@@ -64,10 +64,15 @@ const dataVaultSlice = createSlice({
     },
     receiveStorageInformation (state: DataVaultState, { payload: { storage } }: PayloadAction<{ storage: DataVaultStorageState }>) {
       state.storage = storage
+    },
+    receiveKeys (state: DataVaultState, { payload: { keys } }: PayloadAction<{ keys: string[] }>) {
+      keys.forEach((key: string) => {
+        key.endsWith('Credential') ? state.credentials[key] = [] : state.declarativeDetails[key] = []
+      })
     }
   }
 })
 
-export const { receiveKeyData, addContentToKey, removeContentfromKey, swapContentById, receiveStorageInformation } = dataVaultSlice.actions
+export const { receiveKeyData, addContentToKey, removeContentfromKey, swapContentById, receiveStorageInformation, receiveKeys } = dataVaultSlice.actions
 
 export default dataVaultSlice.reducer

--- a/src/app/state/reducers/datavault.ts
+++ b/src/app/state/reducers/datavault.ts
@@ -37,22 +37,20 @@ export const initialState: DataVaultState = {
   storage: undefined
 }
 
+const getBucket = (key: string) => key.endsWith('Credential') ? 'credentials' : 'declarativeDetails'
+
 const dataVaultSlice = createSlice({
   name: 'datavault',
   initialState,
   reducers: {
     receiveKeyData (state: DataVaultState, { payload: { key, content } }: PayloadAction<ReceivePayLoad>) {
-      if (key.endsWith('Credential')) {
-        state.credentials[key] = content
-      } else {
-        state.declarativeDetails[key] = content
-      }
+      state[getBucket(key)][key] = content
     },
     addContentToKey (state: DataVaultState, { payload: { key, content } }: PayloadAction<{ key: string, content: DataVaultContent }>) {
       state.declarativeDetails[key] ? state.declarativeDetails[key].push(content) : state.declarativeDetails[key] = [content]
     },
     removeContentfromKey (state: DataVaultState, { payload: { key, id } }: PayloadAction<{ key: string, id: string }>) {
-      const bucket = key.endsWith('Credential') ? 'credentials' : 'declarativeDetails'
+      const bucket = getBucket(key)
       state[bucket][key] = state[bucket][key].filter((item: DataVaultContent) => item.id !== id)
 
       if (state[bucket][key].length === 0) {

--- a/src/assets/scss/components/_button.scss
+++ b/src/assets/scss/components/_button.scss
@@ -70,3 +70,8 @@ button.icon:hover {
 button.icon:disabled {
   opacity: .25;
 }
+
+button.small {
+  padding: 5px 25px;
+  font-size: 14px;
+}

--- a/src/assets/scss/screens/_data-vault.scss
+++ b/src/assets/scss/screens/_data-vault.scss
@@ -41,6 +41,10 @@
       border-bottom: 1px solid $lightGray;
     }
 
+    .decrypt {
+      text-align: right;
+    }
+
     .content-row {
       width: 100%;
       display: flex;


### PR DESCRIPTION
Instead of loading all the content at the login start, download the keys for the user and add a button for the user to click to download the data of that key.

- Create DecryptButton component that is used for both credentials and declarativeDetails
- Delete the key in the reducer if the user has removed the last piece of content
- Show a message to download if there is content left encrypted.

This does not handle using wallets that don't expose the publicKey, or wallets that don't decrypt. These will come in a later PR.

~Draft status right now, pending merge of #39. Then I will update this to merge to `develop`, update its status, and request reviewers.~