### PR TITLE
Delete credential from the Data Vault

### DIFF
--- a/src/app/DataVault/DataVaultComponent.tsx
+++ b/src/app/DataVault/DataVaultComponent.tsx
@@ -47,7 +47,10 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
       </div>
       <div className="container">
         <div className="column">
-          <CredentialDisplay credentials={credentials} />
+          <CredentialDisplay
+            credentials={credentials}
+            deleteValue={handleDelete}
+          />
         </div>
       </div>
       <div className="container">

--- a/src/app/DataVault/components/DeleteDvContentButton.test.tsx
+++ b/src/app/DataVault/components/DeleteDvContentButton.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+import Component from './DeleteDvContentButton'
+
+describe('Component: DeleteDvContentButton.test', () => {
+  const defaultProps = {
+    itemKey: 'MY_KEY',
+    item: { id: '4', content: 'hello' },
+    deleteValue: jest.fn()
+  }
+
+  it('renders the component', () => {
+    const wrapper = mount(<Component {...defaultProps} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('handles delete click', async () => {
+    const deleteFunction = jest.fn()
+    const deleteValue = (key: string, id: string) => new Promise((resolve) => resolve(deleteFunction(key, id)))
+    const wrapper = mount(<Component {...defaultProps} key="MY_KEY" deleteValue={deleteValue} />)
+
+    await act(async () => {
+      await wrapper.find('button.delete').simulate('click')
+      wrapper.update()
+      await wrapper.find('.delete-modal').find('.column').at(1).find('button').simulate('click')
+
+      await act(async () => {
+        expect(deleteFunction).toBeCalledTimes(1)
+        expect(deleteFunction).toBeCalledWith('MY_KEY', '4')
+      })
+    })
+  })
+})

--- a/src/app/DataVault/components/DeleteDvContentButton.tsx
+++ b/src/app/DataVault/components/DeleteDvContentButton.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react'
+import trashIcon from '../../../assets/images/icons/trash.svg'
+import BinaryModal from '../../../components/Modal/BinaryModal'
+import { DataVaultContent } from '../../state/reducers/datavault'
+
+interface Interface {
+  itemKey: string
+  item: DataVaultContent
+  deleteValue: (key: string, id: string) => Promise<any>
+}
+
+const DeleteDvContentButton: React.FC<Interface> = ({
+  itemKey, item, deleteValue
+}) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isError, setIsError] = useState<null | string>(null)
+  const [isDeleting, setIsDeleting] = useState<boolean>(false)
+
+  const handleDeleteItem = () => {
+    setIsLoading(true)
+    setIsError(null)
+
+    deleteValue(itemKey, item.id)
+      .then(() => setIsDeleting(false))
+      .catch((err: Error) => setIsError(err.message))
+      .finally(() => setIsLoading(false))
+  }
+
+  return (
+    <>
+      <button
+        disabled={isLoading}
+        className="icon delete"
+        onClick={() => setIsDeleting(true)}>
+        <img src={trashIcon} alt="Delete Item" />
+      </button>
+
+      <BinaryModal
+        show={isDeleting}
+        onClose={() => setIsDeleting(false)}
+        onConfirm={() => isDeleting && handleDeleteItem()}
+        disabled={isLoading}
+        strings={{ text: 'Do you want to delete this item from the data vault?', confirm: 'Yes', deny: 'No' }}
+        className="delete-modal"
+      />
+    </>
+  )
+}
+
+export default DeleteDvContentButton

--- a/src/app/DataVault/components/DeleteDvContentButton.tsx
+++ b/src/app/DataVault/components/DeleteDvContentButton.tsx
@@ -38,10 +38,11 @@ const DeleteDvContentButton: React.FC<Interface> = ({
       <BinaryModal
         show={isDeleting}
         onClose={() => setIsDeleting(false)}
-        onConfirm={() => isDeleting && handleDeleteItem()}
+        onConfirm={handleDeleteItem}
         disabled={isLoading}
         strings={{ text: 'Do you want to delete this item from the data vault?', confirm: 'Yes', deny: 'No' }}
         className="delete-modal"
+        error={isError}
       />
     </>
   )

--- a/src/app/DataVault/panels/AddDeclarativeDetails.tsx
+++ b/src/app/DataVault/panels/AddDeclarativeDetails.tsx
@@ -23,7 +23,8 @@ const AddDeclarativeDetails: React.FC<AddDeclarativeDetailsInterface> = ({ addDe
       return setIsError('Type and Content cannot be empty.')
     }
 
-    addDeclarativeDetail(`DD_${type.toUpperCase()}`, content)
+    // addDeclarativeDetail(`DD_${type.toUpperCase()}`, content)
+    addDeclarativeDetail(type, content)
       .then(() => {
         setIsLoading(false)
         setContent('')

--- a/src/app/DataVault/panels/AddDeclarativeDetails.tsx
+++ b/src/app/DataVault/panels/AddDeclarativeDetails.tsx
@@ -23,8 +23,7 @@ const AddDeclarativeDetails: React.FC<AddDeclarativeDetailsInterface> = ({ addDe
       return setIsError('Type and Content cannot be empty.')
     }
 
-    // addDeclarativeDetail(`DD_${type.toUpperCase()}`, content)
-    addDeclarativeDetail(type, content)
+    addDeclarativeDetail(`DD_${type.toUpperCase()}`, content)
       .then(() => {
         setIsLoading(false)
         setContent('')

--- a/src/app/DataVault/panels/CredentialDisplay.tsx
+++ b/src/app/DataVault/panels/CredentialDisplay.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
-import CredentialViewInterface from '../../../components/CredentialView/CredentialView'
+import CredentialView from '../../../components/CredentialView/CredentialView'
 import Panel from '../../../components/Panel/Panel'
 import { DataVaultContent, DataVaultKey } from '../../state/reducers/datavault'
 import CredentialIcon from '../../../assets/images/icons/credential.svg'
+import DeleteDvContentButton from '../components/DeleteDvContentButton'
 
 interface CredentialDisplayInterface {
   credentials: DataVaultKey
+  deleteValue: (key: string, id: string) => Promise<any>
 }
 
-const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials }) => {
+const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, deleteValue }) => {
   return (
     <Panel title={<><img src={CredentialIcon} /> Credentials</>} className="display credentials">
       <table>
@@ -26,7 +28,12 @@ const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials }
                 <td>
                   <ul>
                     {credentials[key].map((item: DataVaultContent) =>
-                      <li key={item.id}><CredentialViewInterface jwt={item.content} /></li>)}
+                      <li key={item.id}>
+                        <CredentialView
+                          jwt={item.content}
+                          options={<DeleteDvContentButton item={item} itemKey={key} deleteValue={deleteValue} />}
+                        />
+                      </li>)}
                   </ul>
                 </td>
               </tr>

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
@@ -38,6 +38,7 @@ describe('Component: DeclarativeDetailsDisplay', () => {
     expect(wrapper.find('tbody').children()).toHaveLength(1)
   })
 
+<<<<<<< HEAD
   it('handles delete click', async () => {
     const deleteFunction = jest.fn()
     const deleteValue = (key: string, id: string) => new Promise((resolve) => resolve(deleteFunction(key, id)))
@@ -53,6 +54,8 @@ describe('Component: DeclarativeDetailsDisplay', () => {
     })
   })
 
+=======
+>>>>>>> c57224c... Extract DeleteButton into its own component
   it('handles swap click', async () => {
     const editFunction = jest.fn()
     const swapValue = (key:string, content: string, id: string) => new Promise((resolve) => resolve(editFunction(key, content, id)))

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.test.tsx
@@ -38,24 +38,6 @@ describe('Component: DeclarativeDetailsDisplay', () => {
     expect(wrapper.find('tbody').children()).toHaveLength(1)
   })
 
-<<<<<<< HEAD
-  it('handles delete click', async () => {
-    const deleteFunction = jest.fn()
-    const deleteValue = (key: string, id: string) => new Promise((resolve) => resolve(deleteFunction(key, id)))
-    const wrapper = mount(<DeclarativeDetailsDisplay details={mockDeclarativeDetials} deleteValue={deleteValue} swapValue={jest.fn()} />)
-
-    wrapper.find('.content-row').at(0).find('button.delete').simulate('click')
-
-    await act(async () => {
-      await wrapper.find('.delete-modal').find('.column').at(1).find('button').simulate('click')
-
-      expect(deleteFunction).toBeCalledTimes(1)
-      expect(deleteFunction).toBeCalledWith('EMAIL', '1')
-    })
-  })
-
-=======
->>>>>>> c57224c... Extract DeleteButton into its own component
   it('handles swap click', async () => {
     const editFunction = jest.fn()
     const swapValue = (key:string, content: string, id: string) => new Promise((resolve) => resolve(editFunction(key, content, id)))

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react'
 import Panel from '../../../components/Panel/Panel'
 import declarativeIcon from '../../../assets/images/icons/declarative-details.svg'
-import trashIcon from '../../../assets/images/icons/trash.svg'
 import pencilIcon from '../../../assets/images/icons/pencil.svg'
 import { DataVaultContent, DataVaultKey } from '../../state/reducers/datavault'
-import BinaryModal from '../../../components/Modal/BinaryModal'
 import EditValueModal from '../../../components/Modal/EditValueModal'
+import DeleteDvContentButton from '../components/DeleteDvContentButton'
 
 interface DeclarativeDetailsDisplayInterface {
   deleteValue: (key: string, id: string) => Promise<any>
@@ -13,24 +12,12 @@ interface DeclarativeDetailsDisplayInterface {
   details: DataVaultKey
 }
 
-const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = ({ details, deleteValue, swapValue }) => {
-  interface DeleteItemI { key: string; id: string }
+const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = ({ details, deleteValue, swapValue, getKeyContent }) => {
   interface EditItemI { key: string; item: DataVaultContent }
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [isError, setIsError] = useState<null | string>(null)
-  const [isDeleting, setIsDeleting] = useState<null | DeleteItemI>(null)
   const [isEditing, setIsEditing] = useState<null | EditItemI>(null)
-
-  const handleDeleteItem = (item: DeleteItemI) => {
-    setIsLoading(true)
-    setIsError(null)
-
-    deleteValue(item.key, item.id)
-      .then(() => setIsDeleting(null))
-      .catch((err: Error) => setIsError(err.message))
-      .finally(() => setIsLoading(false))
-  }
 
   const handleEditItem = (newValue: string, existingItem: EditItemI) => {
     if (newValue === existingItem.item.content) {
@@ -78,12 +65,7 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
                           >
                             <img src={pencilIcon} alt="Edit item" />
                           </button>
-                          <button
-                            disabled={isLoading}
-                            className="icon delete"
-                            onClick={() => setIsDeleting({ key, id: item.id })}>
-                            <img src={trashIcon} alt="Delete Item" />
-                          </button>
+                          <DeleteDvContentButton itemKey={key} item={item} deleteValue={deleteValue} />
                         </div>
                       </div>
                     ))}
@@ -106,15 +88,6 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
         initValue={isEditing ? isEditing.item.content : ''}
         inputType="textarea"
         error={isError}
-      />
-
-      <BinaryModal
-        show={isDeleting !== null}
-        onClose={() => setIsDeleting(null)}
-        onConfirm={() => isDeleting && handleDeleteItem(isDeleting)}
-        disabled={isLoading}
-        strings={{ text: 'Do you want to delete this item from the data vault?', confirm: 'Yes', deny: 'No' }}
-        className="delete-modal"
       />
     </Panel>
   )

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
@@ -12,7 +12,7 @@ interface DeclarativeDetailsDisplayInterface {
   details: DataVaultKey
 }
 
-const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = ({ details, deleteValue, swapValue, getKeyContent }) => {
+const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = ({ details, deleteValue, swapValue }) => {
   interface EditItemI { key: string; item: DataVaultContent }
 
   const [isLoading, setIsLoading] = useState<boolean>(false)

--- a/src/app/state/reducers/datavault.test.ts
+++ b/src/app/state/reducers/datavault.test.ts
@@ -102,7 +102,15 @@ describe('dataVault slice', () => {
         store.dispatch(removeContentfromKey({ key: 'MY_KEY', id: '1' }))
         store.dispatch(removeContentfromKey({ key: 'MY_KEY', id: '2' }))
 
-        expect(store.getState().declarativeDetails).toEqual({ MY_KEY: [] })
+        expect(store.getState().declarativeDetails).toEqual({})
+      })
+
+      test('it deletes credentials from list', () => {
+        const content = [{ id: '3', content: 'theCredential' }, { id: '4', content: 'c2' }]
+        store.dispatch(receiveKeyData({ key: 'helloCredential', content }))
+
+        store.dispatch(removeContentfromKey({ key: 'helloCredential', id: '3' }))
+        expect(store.getState().credentials).toEqual({ helloCredential: [{ id: '4', content: 'c2' }] })
       })
     })
 

--- a/src/app/state/reducers/datavault.ts
+++ b/src/app/state/reducers/datavault.ts
@@ -52,7 +52,12 @@ const dataVaultSlice = createSlice({
       state.declarativeDetails[key] ? state.declarativeDetails[key].push(content) : state.declarativeDetails[key] = [content]
     },
     removeContentfromKey (state: DataVaultState, { payload: { key, id } }: PayloadAction<{ key: string, id: string }>) {
-      state.declarativeDetails[key] = state.declarativeDetails[key].filter((item: DataVaultContent) => item.id !== id)
+      const bucket = key.endsWith('Credential') ? 'credentials' : 'declarativeDetails'
+      state[bucket][key] = state[bucket][key].filter((item: DataVaultContent) => item.id !== id)
+
+      if (state[bucket][key].length === 0) {
+        delete state[bucket][key]
+      }
     },
     swapContentById (state: DataVaultState, { payload: { key, id, content } }: PayloadAction<SwapPayLoad>) {
       state.declarativeDetails[key] = state.declarativeDetails[key].map((item: DataVaultContent) => item.id === id ? { ...item, content } : item)

--- a/src/components/CredentialView/CredentialView.test.tsx
+++ b/src/components/CredentialView/CredentialView.test.tsx
@@ -25,4 +25,9 @@ describe('Component: CredentialView', () => {
     expect(wrapper.find('.alert').text()).toBe('Could not decode credential!The raw data is displayed below.')
     expect(wrapper.find('div.raw').text()).toBe('Hello World!')
   })
+
+  it('adds custom options', () => {
+    const wrapper = mount(<CredentialView jwt={sampleJwt} options={<p className="test">Extra!</p>} />)
+    expect(wrapper.find('.options').find('p.test').text()).toBe('Extra!')
+  })
 })

--- a/src/components/CredentialView/CredentialView.tsx
+++ b/src/components/CredentialView/CredentialView.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { ReactNode, useEffect, useState } from 'react'
 import jwtDecode from 'jwt-decode'
 
 interface CredentialViewInterface {
   jwt: string
+  options?: ReactNode
 }
 
-const CredentialView: React.FC<CredentialViewInterface> = ({ jwt }) => {
+const CredentialView: React.FC<CredentialViewInterface> = ({ jwt, options }) => {
   const [showRaw, setShowRaw] = useState<boolean>(false)
   const [error, setError] = useState<null | string>(null)
   const [prettyJson, setPrettyJson] = useState<string>('')
@@ -42,6 +43,7 @@ const CredentialView: React.FC<CredentialViewInterface> = ({ jwt }) => {
       {!error && (
         <div className="options">
           <button className="icon raw" onClick={() => setShowRaw(!showRaw)}>{showRaw ? 'Hide' : 'View'} Raw</button>
+          {options}
         </div>
       )}
     </div>

--- a/src/components/Modal/BinaryModal.test.tsx
+++ b/src/components/Modal/BinaryModal.test.tsx
@@ -46,4 +46,9 @@ describe('Component: BinaryModal', () => {
     expect(onClose).toBeCalledTimes(0)
     expect(onDeny).toBeCalledTimes(1)
   })
+
+  it('shows an error', () => {
+    const wrapper = mount(<BinaryModal show={true} onConfirm={jest.fn()} onClose={jest.fn()} onDeny={jest.fn()} error="An Error!" />)
+    expect(wrapper.find('.alert').text()).toBe('An Error!')
+  })
 })

--- a/src/components/Modal/BinaryModal.tsx
+++ b/src/components/Modal/BinaryModal.tsx
@@ -12,13 +12,14 @@ interface BinaryModalInterface {
     deny?: string
   }
   className?: string
+  error?: string | null
   onConfirm: () => void
   onDeny?: () => void
   onClose: () => void
 }
 
 const BinaryModal: React.FC<BinaryModalInterface> = ({
-  show, title, disabled, className, onConfirm, onClose, onDeny, strings
+  show, title, disabled, className, error, onConfirm, onClose, onDeny, strings
 }) => {
   return (
     <Modal show={show} className={className} onClose={onClose} title={title || 'Are you sure?'}>
@@ -35,6 +36,7 @@ const BinaryModal: React.FC<BinaryModalInterface> = ({
           </BaseButton>
         </div>
       </div>
+      {error && <div className="alert error">{error}</div>}
     </Modal>
   )
 }


### PR DESCRIPTION
Allow a user to delete a credential from their data vault

- DeleteDvContentButton component to handle the UI/UX. Passes promise up the tree
- Implement this button in Declarative Details and then in Credentials
- Expand action in reducer to remove data from either DD or Credentials
- Move test from DD View panel to new DeleteButton

~Draft, pending merge of #39 and #40~