### PR TITLE
Allow user to Download contents from DataVault

### DIFF
--- a/src/app/DataVault/DataVaultComponent.tsx
+++ b/src/app/DataVault/DataVaultComponent.tsx
@@ -5,6 +5,7 @@ import AddDeclarativeDetails from './panels/AddDeclarativeDetails'
 import { DataVaultKey } from '../state/reducers/datavault'
 import { Web3ProviderContext } from '../../providerContext'
 import CredentialDisplay from './panels/CredentialDisplay'
+import DownloadBackup from './panels/DownloadBackup'
 
 interface DataVaultComponentProps {
   declarativeDetails: DataVaultKey
@@ -12,10 +13,11 @@ interface DataVaultComponentProps {
   addDeclarativeDetail: (client: DataVaultWebClient, key: string, content: string) => any
   deleteValue: (client: DataVaultWebClient, key: string, id: string) => any
   swapValue: (client: DataVaultWebClient, key: string, content: string, id: string) => any
+  downloadBackup: (client: DataVaultWebClient) => any
 }
 
 const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
-  addDeclarativeDetail, declarativeDetails, credentials, deleteValue, swapValue
+  addDeclarativeDetail, declarativeDetails, credentials, deleteValue, swapValue, downloadBackup
 }) => {
   const context = useContext(Web3ProviderContext)
 
@@ -25,6 +27,7 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
     context.dvClient && deleteValue(context.dvClient, key, id)
   const handleSwap = (key: string, content: string, id: string) =>
     context.dvClient && swapValue(context.dvClient, key, content, id)
+  const handleDownload = () => context.dvClient && downloadBackup(context.dvClient)
 
   return (
     <div className="content data-vault">
@@ -46,6 +49,12 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
         <div className="column">
           <CredentialDisplay credentials={credentials} />
         </div>
+      </div>
+      <div className="container">
+        <div className="column">
+          <DownloadBackup handleDownload={handleDownload} />
+        </div>
+        <div className="column"></div>
       </div>
     </div>
   )

--- a/src/app/DataVault/DataVaultContainer.ts
+++ b/src/app/DataVault/DataVaultContainer.ts
@@ -4,7 +4,7 @@ import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 import { stateInterface } from '../state/configureStore'
 import DataVaultComponent from './DataVaultComponent'
 import { AnyAction } from 'redux'
-import { createDataVaultContent, deleteDataVaultContent, swapDataVaultContent } from '../state/operations/datavault'
+import { createDataVaultContent, deleteDataVaultContent, swapDataVaultContent, downloadBackup } from '../state/operations/datavault'
 
 const mapStateToProps = (state: stateInterface) => ({
   declarativeDetails: state.datavault.declarativeDetails,
@@ -17,7 +17,8 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<stateInterface, {}, AnyActio
   deleteValue: (client: DataVaultWebClient, key: string, id: string) =>
     dispatch(deleteDataVaultContent(client, key, id)),
   swapValue: (client: DataVaultWebClient, key: string, content: string, id: string) =>
-    dispatch(swapDataVaultContent(client, key, content, id))
+    dispatch(swapDataVaultContent(client, key, content, id)),
+  downloadBackup: (client: DataVaultWebClient) => downloadBackup(client)
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(DataVaultComponent)

--- a/src/app/DataVault/panels/DownloadBackup.test.tsx
+++ b/src/app/DataVault/panels/DownloadBackup.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import DownloadBackup from './DownloadBackup'
+
+describe('Component: DownloadBackup', () => {
+  it('renders the component', () => {
+    const wrapper = mount(<DownloadBackup handleDownload={jest.fn()} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('handles download click', async () => {
+    const download = jest.fn()
+    const wrapper = mount(<DownloadBackup handleDownload={() => Promise.resolve(download())} />)
+
+    await act(async () => {
+      await wrapper.find('button').simulate('click')
+      expect(download).toBeCalledTimes(1)
+    })
+  })
+
+  it('shows an error', async () => {
+    const wrapper = mount(<DownloadBackup handleDownload={() => Promise.reject(new Error('An Error'))} />)
+
+    await act(async () => {
+      await wrapper.find('button').simulate('click')
+    })
+
+    wrapper.update()
+    expect(wrapper.find('div.alert').text()).toBe('An Error')
+  })
+})

--- a/src/app/DataVault/panels/DownloadBackup.tsx
+++ b/src/app/DataVault/panels/DownloadBackup.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import Panel from '../../../components/Panel/Panel'
+import downloadIcon from '../../../assets/images/icons/download.svg'
+import { BaseButton } from '../../../components/Buttons'
+import LoadingComponent from '../../../components/Loading/LoadingComponent'
+
+interface DownloadBackupInterface {
+  handleDownload: () => Promise<any>
+}
+
+const DownloadBackup: React.FC<DownloadBackupInterface> = ({
+  handleDownload
+}) => {
+  const initStatus = { isLoading: false, isError: null }
+  const [status, setStatus] = useState<{ isLoading: boolean; isError: string | null }>({
+    isLoading: false,
+    isError: null
+  })
+
+  const download = () => {
+    setStatus({ ...initStatus, isLoading: true })
+    handleDownload()
+      .then(() => setStatus(initStatus))
+      .catch((error: Error) => setStatus({ ...initStatus, isError: error.message }))
+  }
+
+  return (
+    <Panel title={<><img src={downloadIcon} /> Download Backup</>}>
+      <p>Download a backup file of all the keys and IPFS hashes that are stored in the DataVault.</p>
+      <p><BaseButton onClick={download} disabled={status.isLoading} className="small">
+        Download Backup
+      </BaseButton></p>
+      {status.isLoading && <LoadingComponent />}
+      {status.isError && <div className="alert error">{status.isError}</div>}
+    </Panel>
+  )
+}
+
+export default DownloadBackup

--- a/src/app/state/operations/datavault.ts
+++ b/src/app/state/operations/datavault.ts
@@ -4,7 +4,7 @@ import DataVaultWebClient, { AuthManager, EncryptionManager } from '@rsksmart/ip
 import { createDidFormat } from '../../../formatters'
 import { addContentToKey, DataVaultContent, receiveKeyData, removeContentfromKey, swapContentById, receiveStorageInformation, DataVaultStorageState, DataVaultKey } from '../reducers/datavault'
 import { getDataVault } from '../../../config/getConfig'
-import { CreateContentResponse } from '@rsksmart/ipfs-cpinner-client/lib/types'
+import { Backup, CreateContentResponse } from '@rsksmart/ipfs-cpinner-client/lib/types'
 
 /**
  * Create DataVault Clinet
@@ -120,3 +120,19 @@ export const dataVaultStart = (provider: any, address: string, chainId: number, 
     })
     .catch((err: any) => callback(null, err))
 }
+
+/**
+ * Download backup text file from the DataVault
+ * @param client DataVault Client
+ */
+export const downloadBackup = (client: DataVaultWebClient) =>
+  client.getBackup()
+    .then((value: Backup) => JSON.stringify(value))
+    .then((value: string) => {
+      const element = document.createElement('a')
+      element.href = URL.createObjectURL(new Blob([value], { type: 'text/plain;charset=utf-8' }))
+      element.download = 'dataVaultBackup.txt'
+      document.body.appendChild(element)
+      element.click()
+      element.remove()
+    })

--- a/src/assets/images/icons/download.svg
+++ b/src/assets/images/icons/download.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 11 12" style="enable-background:new 0 0 11 12;" xml:space="preserve" width="11" height="12" >
+<style type="text/css">
+	.st0{fill:none;stroke:#50555C;}
+</style>
+<line class="st0" x1="5.5" y1="0.5" x2="5.5" y2="9.5"/>
+<path class="st0" d="M10,4.5l-4.5,5L1,4.5"/>
+<line class="st0" x1="10" y1="12" x2="1" y2="12"/>
+</svg>


### PR DESCRIPTION
- Panel at the bottom of the DV screen for downloading a backup
- Component to handle UX
- Operations function that calls the download function, creates text file and downloads it to the user

Example file: [dataVaultBackup (6).txt](https://github.com/rsksmart/rif-identity-manager/files/5814520/dataVaultBackup.6.txt)
