### PR TITLE
Handle connections to DV where encryption is not possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.0.5"
   },
   "devDependencies": {
-    "@rsksmart/ipfs-cpinner-client": "0.1.1-beta.7",
+    "@rsksmart/ipfs-cpinner-client": "0.1.1-beta.8",
     "@rsksmart/rlogin": "0.0.1-beta.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/src/app/DataVault/DataVaultComponent.tsx
+++ b/src/app/DataVault/DataVaultComponent.tsx
@@ -7,6 +7,7 @@ import { Web3ProviderContext } from '../../providerContext'
 import CredentialDisplay from './panels/CredentialDisplay'
 import DownloadBackup from './panels/DownloadBackup'
 import { createPresentation } from '../../features/credentials'
+import { getProviderName } from '../../ethrpc'
 
 interface DataVaultComponentProps {
   declarativeDetails: DataVaultKey
@@ -37,7 +38,10 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
     <div className="content data-vault">
       <div className="container">
         <div className="column">
-          <AddDeclarativeDetails addDeclarativeDetail={handleAdd} />
+          <AddDeclarativeDetails
+            addDeclarativeDetail={handleAdd}
+            providerName={getProviderName(context.provider)}
+          />
         </div>
       </div>
       <div className="container">

--- a/src/app/DataVault/components/DownloadErrorMessage.tsx
+++ b/src/app/DataVault/components/DownloadErrorMessage.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+interface DownloadErrorMessageInterface {
+ keyError: string
+}
+
+const DownloadErrorMessage: React.FC<DownloadErrorMessageInterface> = ({ keyError }) => (
+  <p className="alert error">This content is encrypted, and your wallet is unable to decrypt the key <em>{keyError}</em>.</p>
+)
+
+export default DownloadErrorMessage

--- a/src/app/DataVault/panels/AddDeclarativeDetails.test.tsx
+++ b/src/app/DataVault/panels/AddDeclarativeDetails.test.tsx
@@ -1,16 +1,17 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
 import AddDeclarativeDetails from './AddDeclarativeDetails'
+import { PROVIDERS } from '../../../ethrpc'
 
 describe('Component: AddDeclarativeDetails', () => {
   it('renders the component', () => {
-    const wrapper = shallow(<AddDeclarativeDetails addDeclarativeDetail={jest.fn()} />)
+    const wrapper = shallow(<AddDeclarativeDetails addDeclarativeDetail={jest.fn()} providerName={PROVIDERS.METAMASK} />)
     expect(wrapper).toBeDefined()
   })
 
   it('adds handles errors if type and content is empty', () => {
     const submitData = jest.fn()
-    const wrapper = mount(<AddDeclarativeDetails addDeclarativeDetail={submitData} />)
+    const wrapper = mount(<AddDeclarativeDetails addDeclarativeDetail={submitData} providerName={PROVIDERS.METAMASK} />)
     const button = wrapper.find('button.submit')
     button.simulate('click')
     expect(submitData).toBeCalledTimes(0)
@@ -20,5 +21,10 @@ describe('Component: AddDeclarativeDetails', () => {
     expect(wrapper.find('input.type').props().value).toBe('email')
     button.simulate('click')
     expect(submitData).toBeCalledTimes(0)
+  })
+
+  it('shows a warning message if not metamask', () => {
+    const wrapper = mount(<AddDeclarativeDetails addDeclarativeDetail={jest.fn()} providerName={PROVIDERS.NIFTY} />)
+    expect(wrapper.find('.alert.warning').find('h2').text()).toBe('Warning!')
   })
 })

--- a/src/app/DataVault/panels/AddDeclarativeDetails.tsx
+++ b/src/app/DataVault/panels/AddDeclarativeDetails.tsx
@@ -3,12 +3,14 @@ import { BaseButton } from '../../../components/Buttons'
 import Panel from '../../../components/Panel/Panel'
 import uploadIcon from '../../../assets/images/icons/upload.svg'
 import LoadingComponent from '../../../components/Loading/LoadingComponent'
+import { PROVIDERS } from '../../../ethrpc'
 
 interface AddDeclarativeDetailsInterface {
   addDeclarativeDetail: (key: string, content: string) => Promise<any>
+  providerName: PROVIDERS
 }
 
-const AddDeclarativeDetails: React.FC<AddDeclarativeDetailsInterface> = ({ addDeclarativeDetail }) => {
+const AddDeclarativeDetails: React.FC<AddDeclarativeDetailsInterface> = ({ addDeclarativeDetail, providerName }) => {
   const [type, setType] = useState('')
   const [content, setContent] = useState('')
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -39,6 +41,12 @@ const AddDeclarativeDetails: React.FC<AddDeclarativeDetailsInterface> = ({ addDe
 
   return (
     <Panel title={title} className="add-declarative">
+      {providerName !== PROVIDERS.METAMASK && (
+        <div className="alert warning">
+          <h2>Warning!</h2>
+          <p>Your wallet does not support encrypted content in your data vault. You can still add content, but it will be saved as plaintext.</p>
+        </div>
+      )}
       <div className="container">
         <div className="column">
           <p className="title">Type</p>
@@ -64,8 +72,8 @@ const AddDeclarativeDetails: React.FC<AddDeclarativeDetailsInterface> = ({ addDe
         </div>
       </div>
       {isError && (
-        <div className="error container">
-          <div className="alert error">{isError}</div>
+        <div className="alert error">
+          <p>{isError}</p>
         </div>
       )}
 

--- a/src/app/DataVault/panels/CredentialDisplay.tsx
+++ b/src/app/DataVault/panels/CredentialDisplay.tsx
@@ -6,6 +6,7 @@ import CredentialIcon from '../../../assets/images/icons/credential.svg'
 import DecryptKey from '../components/DecryptKey'
 import DeleteDvContentButton from '../components/DeleteDvContentButton'
 import PresentCredential from '../components/PresentCredential'
+import DownloadErrorMessage from '../components/DownloadErrorMessage'
 
 interface CredentialDisplayInterface {
   credentials: DataVaultKey
@@ -16,15 +17,18 @@ interface CredentialDisplayInterface {
 
 const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, getKeyContent, deleteValue, createPresentation }) => {
   const [isGettingContent, setIsGettingContent] = useState<string[]>([])
+  const [isDownloadError, setIsDownloadError] = useState<null | string>(null)
   const handleGetContent = (key: string) => {
     setIsGettingContent([...isGettingContent, key])
+    setIsDownloadError(null)
     getKeyContent(key)
-      .catch((err: Error) => console.log(err.message))
+      .catch(() => setIsDownloadError(key))
       .finally(() => setIsGettingContent(isGettingContent.filter((k: string) => k !== key)))
   }
 
   return (
     <Panel title={<><img src={CredentialIcon} /> Credentials</>} className="display credentials">
+      {isDownloadError && <DownloadErrorMessage keyError={isDownloadError} />}
       <table>
         <thead>
           <tr>

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
@@ -19,6 +19,7 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [isError, setIsError] = useState<null | string>(null)
+  const [isDownloadError, setIsDownloadError] = useState<null | string>(null)
   const [isEditing, setIsEditing] = useState<null | EditItemI>(null)
   const [isGettingContent, setIsGettingContent] = useState<string[]>([])
 
@@ -40,9 +41,10 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
   }
 
   const handleGetContent = (key: string) => {
+    setIsDownloadError(null)
     setIsGettingContent([...isGettingContent, key])
     getKeyContent(key)
-      .catch((err: Error) => console.log(err))
+      .catch(() => setIsDownloadError(key))
       .finally(() => {
         setIsGettingContent(isGettingContent.filter((k: string) => k !== key))
       })
@@ -66,6 +68,7 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
   return (
     <Panel title={<><img src={declarativeIcon} /> Declarative Details</>} className="display">
       {showDownloadMessage() && <p className="intro">Click on the download button to decrypt the content. Your wallet will request to decrypt each piece of content.</p>}
+      {isDownloadError && <p className="alert error">This content is encrypted, and your wallet is unable to decrypt the key <em>{isDownloadError}</em>.</p>}
       <table>
         <thead>
           <tr>

--- a/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
+++ b/src/app/DataVault/panels/DeclarativeDetailsDisplay.tsx
@@ -6,6 +6,7 @@ import { DataVaultContent, DataVaultKey } from '../../state/reducers/datavault'
 import EditValueModal from '../../../components/Modal/EditValueModal'
 import DeleteDvContentButton from '../components/DeleteDvContentButton'
 import DecryptKey from '../components/DecryptKey'
+import DownloadErrorMessage from '../components/DownloadErrorMessage'
 
 interface DeclarativeDetailsDisplayInterface {
   deleteValue: (key: string, id: string) => Promise<any>
@@ -68,7 +69,7 @@ const DeclarativeDetailsDisplay: React.FC<DeclarativeDetailsDisplayInterface> = 
   return (
     <Panel title={<><img src={declarativeIcon} /> Declarative Details</>} className="display">
       {showDownloadMessage() && <p className="intro">Click on the download button to decrypt the content. Your wallet will request to decrypt each piece of content.</p>}
-      {isDownloadError && <p className="alert error">This content is encrypted, and your wallet is unable to decrypt the key <em>{isDownloadError}</em>.</p>}
+      {isDownloadError && <DownloadErrorMessage keyError={isDownloadError} />}
       <table>
         <thead>
           <tr>

--- a/src/app/state/operations/datavault.ts
+++ b/src/app/state/operations/datavault.ts
@@ -5,6 +5,7 @@ import { createDidFormat } from '../../../formatters'
 import { addContentToKey, DataVaultContent, receiveKeyData, removeContentfromKey, swapContentById, receiveStorageInformation, DataVaultStorageState, DataVaultKey, receiveKeys } from '../reducers/datavault'
 import { getDataVault } from '../../../config/getConfig'
 import { Backup, CreateContentResponse } from '@rsksmart/ipfs-cpinner-client/lib/types'
+import { getProviderName, PROVIDERS } from '../../../ethrpc'
 
 /**
  * Create DataVault Clinet
@@ -20,10 +21,14 @@ export const createClient = (provider: any, address: string, chainId: number) =>
   const decrypt = (hexCypher: string) => provider.request({ method: 'eth_decrypt', params: [hexCypher, address] })
   const getEncryptionPublicKey = () => provider.request({ method: 'eth_getEncryptionPublicKey', params: [address] })
 
+  const encryptionManager = getProviderName(provider) === PROVIDERS.METAMASK
+    ? new EncryptionManager({ getEncryptionPublicKey, decrypt })
+    : new EncryptionManager({ getEncryptionPublicKey: undefined })
+
   return new DataVaultWebClient({
     serviceUrl,
     authManager: new AuthManager({ did, serviceUrl, personalSign }),
-    encryptionManager: new EncryptionManager({ getEncryptionPublicKey, decrypt })
+    encryptionManager
   })
 }
 

--- a/src/app/state/operations/datavault.ts
+++ b/src/app/state/operations/datavault.ts
@@ -15,15 +15,16 @@ import { getProviderName, PROVIDERS } from '../../../ethrpc'
  */
 export const createClient = (provider: any, address: string, chainId: number) => {
   const serviceUrl = getDataVault()
-  const did = createDidFormat(address, chainId)
+  const did = createDidFormat(address, chainId).toLowerCase()
 
   const personalSign = (data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
   const decrypt = (hexCypher: string) => provider.request({ method: 'eth_decrypt', params: [hexCypher, address] })
   const getEncryptionPublicKey = () => provider.request({ method: 'eth_getEncryptionPublicKey', params: [address] })
+  const mockDecrypt = (_hexCypher: string) => Promise.resolve('Error: Content could not be decrypted by your wallet.')
 
   const encryptionManager = getProviderName(provider) === PROVIDERS.METAMASK
     ? new EncryptionManager({ getEncryptionPublicKey, decrypt })
-    : new EncryptionManager({ getEncryptionPublicKey: undefined })
+    : new EncryptionManager({ getEncryptionPublicKey: undefined, decrypt: mockDecrypt })
 
   return new DataVaultWebClient({
     serviceUrl,

--- a/src/app/state/operations/datavault.ts
+++ b/src/app/state/operations/datavault.ts
@@ -16,7 +16,7 @@ export const createClient = (provider: any, address: string, chainId: number) =>
   const serviceUrl = getDataVault()
   const did = createDidFormat(address, chainId)
 
-  const personalSign = (data: string) => provider.request({ method: 'personal_sign', params: [address, data] })
+  const personalSign = (data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
   const decrypt = (hexCypher: string) => provider.request({ method: 'eth_decrypt', params: [hexCypher, address] })
   const getEncryptionPublicKey = () => provider.request({ method: 'eth_getEncryptionPublicKey', params: [address] })
 

--- a/src/app/state/operations/datavault.ts
+++ b/src/app/state/operations/datavault.ts
@@ -20,7 +20,7 @@ export const createClient = (provider: any, address: string, chainId: number) =>
   const personalSign = (data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
   const decrypt = (hexCypher: string) => provider.request({ method: 'eth_decrypt', params: [hexCypher, address] })
   const getEncryptionPublicKey = () => provider.request({ method: 'eth_getEncryptionPublicKey', params: [address] })
-  const mockDecrypt = (_hexCypher: string) => Promise.resolve('Error: Content could not be decrypted by your wallet.')
+  const mockDecrypt = (_hexCypher: string) => Promise.reject(new Error('Content could not be decrypted by your wallet.'))
 
   const encryptionManager = getProviderName(provider) === PROVIDERS.METAMASK
     ? new EncryptionManager({ getEncryptionPublicKey, decrypt })

--- a/src/assets/scss/_index.scss
+++ b/src/assets/scss/_index.scss
@@ -8,6 +8,7 @@ $mediumGray: #CCCACD;
 $lightGray: #E1E1E1;
 $red: #F28282;
 $deepRed: #952c2c;
+$orange: #ee9240;
 
 $breakpoint-phone: 480px;
 

--- a/src/assets/scss/components/_alert.scss
+++ b/src/assets/scss/components/_alert.scss
@@ -5,10 +5,23 @@
   margin: 1rem 0;
   border: 1px solid transparent;
   border-radius: .25rem;
+
+  h2, p {
+    margin: 0 0 2px 0;
+  }
 }
 
 .alert.error {
   color: $white;
   background-color: $red;
   border-color: $deepRed;
+}
+
+.alert.warning {
+  color: $white;
+  background-color: $orange;
+
+  h2 {
+    color: $white;
+  }
 }

--- a/src/ethrpc.ts
+++ b/src/ethrpc.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import Eth from 'ethjs-query'
 
 export const getNetwork = (provider: any) => new Eth(provider).net_version()
@@ -27,4 +28,26 @@ export const transactionListener = (provider: any, tx: string, userCallback: any
       })
       .catch((err: Error) => userCallback({ error: err.message }))
   , 2000)
+}
+
+export enum PROVIDERS {
+  METAMASK = 'METAMASK',
+  NIFTY = 'NIFTY',
+  WALLET_CONNECT = 'WALLET_CONNECT'
+}
+
+/**
+ * Return the Provider Name. Used to detect DataVault features
+ * @param provider web3Provider
+ */
+export const getProviderName = (provider: any) => {
+  if (provider.isNiftyWallet) {
+    return PROVIDERS.NIFTY
+  }
+  if (provider.isMetaMask) {
+    return PROVIDERS.METAMASK
+  }
+  if (provider.wc) {
+    return provider.WALLET_CONNECT
+  }
 }

--- a/src/formatters.test.tsx
+++ b/src/formatters.test.tsx
@@ -5,7 +5,7 @@ describe('helpers.js', () => {
 
   describe('function: createDidFormat', () => {
     it('creates correct format', () => {
-      expect(createDidFormat(address, 1)).toBe(`did:ethr:mainnet:${address}`)
+      expect(createDidFormat(address, 1)).toBe(`did:ethr:${address}`)
       expect(createDidFormat(address, 30)).toBe(`did:ethr:rsk:${address}`)
       expect(createDidFormat(address, 31)).toBe(`did:ethr:rsk:testnet:${address}`)
       expect(createDidFormat(address, 5777)).toBe(`did:ethr:development:${address}`)

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -6,7 +6,7 @@
  */
 export const createDidFormat = (address: string, chainId: number) => {
   switch (chainId) {
-    case 1: return `did:ethr:mainnet:${address}`
+    case 1: return `did:ethr:${address}`
     case 30: return `did:ethr:rsk:${address}`
     case 31: return `did:ethr:rsk:testnet:${address}`
     case 5777: return `did:ethr:development:${address}`


### PR DESCRIPTION
Handles connections to the DataVault when the Wallet does not expose the public encryption key, or decrypt function.

- Fix issue with WalletConnect to sign data
- Function to return providerType
- Use the function to show an alert if not Metamask
- On decrypt, if trying to decrypt encrypted content via WC or Nifty, throw and handle the error.
- Use pinner client 8

Indirectly resolves #28 by bumping the cpinnet client