### PR TITLE
Create Verifiable Presentations from Credentials stored in the DataVault

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@rsksmart/rsk-testnet-contract-metadata": "^1.0.3",
     "axios": "^0.21.0",
     "bn.js": "^5.1.3",
+    "did-jwt-vc": "^1.0.7",
     "did-resolver": "^2.1.1",
     "ethjs-contract": "^0.2.3",
     "ethjs-query": "^0.3.8",

--- a/src/app/DataVault/DataVaultComponent.tsx
+++ b/src/app/DataVault/DataVaultComponent.tsx
@@ -6,6 +6,7 @@ import { DataVaultKey } from '../state/reducers/datavault'
 import { Web3ProviderContext } from '../../providerContext'
 import CredentialDisplay from './panels/CredentialDisplay'
 import DownloadBackup from './panels/DownloadBackup'
+import { createPresentation } from '../../features/credentials'
 
 interface DataVaultComponentProps {
   declarativeDetails: DataVaultKey
@@ -55,6 +56,7 @@ const DataVaultComponent: React.FC<DataVaultComponentProps> = ({
             credentials={credentials}
             deleteValue={handleDelete}
             getKeyContent={handleGetKeyContent}
+            createPresentation={(jwt: string) => createPresentation(context.provider, jwt)}
           />
         </div>
       </div>

--- a/src/app/DataVault/components/PresentCredential.test.tsx
+++ b/src/app/DataVault/components/PresentCredential.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+import PresentCredential from './PresentCredential'
+
+describe('Component: PresentCredential.test', () => {
+  const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRW1haWwiXSwiY3JlZGVudGlhbFNjaGVtYSI6eyJpZCI6ImRpZDpldGhyOnJzazoweDhhMzJkYTYyNGRkOWZhZDhiZjRmMzJkOTQ1NmYzNzRiNjBkOWFkMjg7aWQ9MWViMmFmNmItMGRlZS02MDkwLWNiNTUtMGVkMDkzZjliMDI2O3ZlcnNpb249MS4wIiwidHlwZSI6Ikpzb25TY2hlbWFWYWxpZGF0b3IyMDE4In0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImVtYWlsQWRkcmVzcyI6Implc3NlQGlvdmxhYnMub3JnIn19LCJzdWIiOiJkaWQ6ZXRocjpyc2s6dGVzdG5ldDoweDNkZDAzZDdkNmMzMTM3ZjFlYjc1ODJiYTU5NTdiOGEyZTI2ZjMwNGEiLCJuYmYiOjE2MDgyMjExNDAsImlzcyI6ImRpZDpldGhyOnJzazoweEZjYzdlNjkxYjNiNjMxODI5Qzk2NDkwNTY5YWE1RjFFMzFlRkFmOGYifQ.omtFUQRGazaMBMkmzHX_X5WaU0qu_fRD8eux_E7nDjrxGXtAKxm-vZioHJdvd7BFF1oQuvzSue7aSVxf5osSIg'
+  const initProps = {
+    jwt,
+    createPresentation: jest.fn()
+  }
+
+  it('renders the component', () => {
+    const wrapper = mount(<PresentCredential {...initProps} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('creates a dummy presentation', async () => {
+    const create = jest.fn()
+    const handleCreate = (input: string) => {
+      create(input)
+      return Promise.resolve('thePresentation')
+    }
+
+    const wrapper = mount(<PresentCredential jwt="testJwt" createPresentation={handleCreate} />)
+
+    await act(async () => {
+      await wrapper.find('button').simulate('click')
+      expect(create).toBeCalledWith('testJwt')
+      wrapper.update()
+
+      await act(async () => {
+        expect(wrapper.find('h2').text()).toBe('Raw JWT')
+        expect(wrapper.find('textarea').props().defaultValue).toBe('thePresentation')
+      })
+    })
+  })
+
+  it('returns an error', async () => {
+    const handleCreate = (_input: string) => Promise.reject(new Error('Custom Error'))
+    const wrapper = mount(<PresentCredential jwt="testJwt" createPresentation={handleCreate} />)
+
+    await wrapper.find('button').simulate('click')
+    await act(async () => {
+      await wrapper.update()
+      await act(async () => {
+        wrapper.update()
+        expect(wrapper.find('.alert').text()).toBe('Custom Error')
+      })
+    })
+  })
+})

--- a/src/app/DataVault/components/PresentCredential.tsx
+++ b/src/app/DataVault/components/PresentCredential.tsx
@@ -1,16 +1,15 @@
-import React, { useContext, useState } from 'react'
+import React, { useState } from 'react'
 import Modal from '../../../components/Modal/Modal'
-import { Web3ProviderContext } from '../../../providerContext'
-import { createPresentation } from '../../../features/credentials'
 import LoadingComponent from '../../../components/Loading/LoadingComponent'
 import CopyButton from '../../../components/CopyButton/CopyButton'
 import { BaseButton } from '../../../components/Buttons'
 
 interface PresentCredentialInterface {
   jwt: string
+  createPresentation: (jwt: string) => Promise<string>
 }
 
-const PresentCredential: React.FC<PresentCredentialInterface> = ({ jwt }) => {
+const PresentCredential: React.FC<PresentCredentialInterface> = ({ jwt, createPresentation }) => {
   interface stateInterface {
     status: 'NONE' | 'LOADING' | 'DONE' | 'ERROR'
     message: string
@@ -18,11 +17,9 @@ const PresentCredential: React.FC<PresentCredentialInterface> = ({ jwt }) => {
   const initialState: stateInterface = { status: 'NONE', message: '' }
   const [state, setState] = useState<stateInterface>(initialState)
 
-  const context = useContext(Web3ProviderContext)
-
   const handleCreate = () => {
     setState({ status: 'LOADING', message: '' })
-    createPresentation(context.provider, jwt)
+    createPresentation(jwt)
       .then((message: string) => setState({ status: 'DONE', message }))
       .catch((error: Error) => setState({ status: 'ERROR', message: error.message }))
   }

--- a/src/app/DataVault/components/PresentCredential.tsx
+++ b/src/app/DataVault/components/PresentCredential.tsx
@@ -1,0 +1,50 @@
+import React, { useContext, useState } from 'react'
+import Modal from '../../../components/Modal/Modal'
+import { DataVaultContent } from '../../state/reducers/datavault'
+import { JwtPresentationPayload, createVerifiablePresentationJwt, Issuer } from 'did-jwt-vc'
+import { Web3ProviderContext } from '../../../providerContext'
+
+interface PresentCredentialInterface {
+  item: DataVaultContent
+}
+
+const PresentCredential: React.FC<PresentCredentialInterface> = ({ item }) => {
+  const [present, setPresent] = useState<null | DataVaultContent>(null)
+  const [presentation, setPresentation] = useState<null | string>(null)
+
+  const address = '0x3dd03d7d6c3137f1eb7582ba5957b8a2e26f304a'
+  const did = 'did:ethr:rsk:testnet:0x3dd03d7d6c3137f1eb7582ba5957b8a2e26f304a'
+  const context = useContext(Web3ProviderContext)
+
+  const createPresentation = async () => {
+    setPresent(item)
+
+    const provider = context.provider
+    const issuer: Issuer = {
+      did,
+      signer: (data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
+    }
+
+    const vpPayload: JwtPresentationPayload = {
+      vp: {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        type: ['VerifiablePresentation'],
+        verifiableCredential: [item.content]
+      }
+    }
+    const vpJwt = await createVerifiablePresentationJwt(vpPayload, issuer)
+    console.log(vpJwt)
+    setPresentation(vpJwt)
+  }
+
+  return (
+    <>
+      <button className="icon" onClick={createPresentation}>Present</button>
+      <Modal show={!!present} onClose={() => setPresent(null)} title="Present Credential">
+        {presentation && <textarea defaultValue={presentation} />}
+      </Modal>
+    </>
+  )
+}
+
+export default PresentCredential

--- a/src/app/DataVault/panels/CredentialDisplay.tsx
+++ b/src/app/DataVault/panels/CredentialDisplay.tsx
@@ -5,6 +5,7 @@ import { DataVaultContent, DataVaultKey } from '../../state/reducers/datavault'
 import CredentialIcon from '../../../assets/images/icons/credential.svg'
 import DecryptKey from '../components/DecryptKey'
 import DeleteDvContentButton from '../components/DeleteDvContentButton'
+import PresentCredential from '../components/PresentCredential'
 
 interface CredentialDisplayInterface {
   credentials: DataVaultKey
@@ -41,7 +42,10 @@ const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, 
                       <li key={item.id}>
                         <CredentialView
                           jwt={item.content}
-                          options={<DeleteDvContentButton item={item} itemKey={key} deleteValue={deleteValue} />}
+                          options={<>
+                            <div><PresentCredential item={item} /></div>
+                            <div><DeleteDvContentButton item={item} itemKey={key} deleteValue={deleteValue} /></div>
+                          </>}
                         />
                       </li>)}
                   </ul>

--- a/src/app/DataVault/panels/CredentialDisplay.tsx
+++ b/src/app/DataVault/panels/CredentialDisplay.tsx
@@ -43,7 +43,7 @@ const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, 
                         <CredentialView
                           jwt={item.content}
                           options={<>
-                            <div><PresentCredential item={item} /></div>
+                            <div><PresentCredential jwt={item.content} /></div>
                             <div><DeleteDvContentButton item={item} itemKey={key} deleteValue={deleteValue} /></div>
                           </>}
                         />

--- a/src/app/DataVault/panels/CredentialDisplay.tsx
+++ b/src/app/DataVault/panels/CredentialDisplay.tsx
@@ -11,9 +11,10 @@ interface CredentialDisplayInterface {
   credentials: DataVaultKey
   getKeyContent: (key: string) => Promise<any>
   deleteValue: (key: string, id: string) => Promise<any>
+  createPresentation: (jwt: string) => Promise<any>
 }
 
-const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, getKeyContent, deleteValue }) => {
+const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, getKeyContent, deleteValue, createPresentation }) => {
   const [isGettingContent, setIsGettingContent] = useState<string[]>([])
   const handleGetContent = (key: string) => {
     setIsGettingContent([...isGettingContent, key])
@@ -43,7 +44,7 @@ const CredentialDisplay: React.FC<CredentialDisplayInterface> = ({ credentials, 
                         <CredentialView
                           jwt={item.content}
                           options={<>
-                            <div><PresentCredential jwt={item.content} /></div>
+                            <div><PresentCredential jwt={item.content} createPresentation={createPresentation} /></div>
                             <div><DeleteDvContentButton item={item} itemKey={key} deleteValue={deleteValue} /></div>
                           </>}
                         />

--- a/src/features/credentials.ts
+++ b/src/features/credentials.ts
@@ -1,0 +1,24 @@
+import { Issuer, JwtPresentationPayload, createVerifiablePresentationJwt } from 'did-jwt-vc'
+import { getAccountAndNetwork } from '../ethrpc'
+import { createDidFormat } from '../formatters'
+
+export const createPresentation = (provider: any, jwt: string) => {
+  return getAccountAndNetwork(provider).then(([address, chainId]) => {
+    const did = createDidFormat(address, chainId)
+    const issuer: Issuer = {
+      did,
+      signer: (data: string) => provider.request({ method: 'personal_sign', params: [data, address] })
+    }
+
+    const vpPayload: JwtPresentationPayload = {
+      vp: {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        type: ['VerifiablePresentation'],
+        verifiableCredential: [jwt],
+        nbf: Math.floor(new Date().getTime() / 1000),
+        exp: Math.floor(new Date().getTime() / 1000) + 3600
+      }
+    }
+    return createVerifiablePresentationJwt(vpPayload, issuer)
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,12 +1594,12 @@
     ethjs-query "^0.3.8"
     ethr-did-resolver "^1.0.2"
 
-"@rsksmart/ipfs-cpinner-client@0.1.1-beta.7":
-  version "0.1.1-beta.7"
-  resolved "https://registry.yarnpkg.com/@rsksmart/ipfs-cpinner-client/-/ipfs-cpinner-client-0.1.1-beta.7.tgz#3f55537792501f76c7119feeb01039f58398e667"
-  integrity sha512-1KERjN9qmJZjRpqHAb9lWNpT04AF/sYKKml17jPeFZjLp5MJl/GDWM+6GYGv97sRTzRjWdtB4SD8qrg23myjZw==
+"@rsksmart/ipfs-cpinner-client@0.1.1-beta.8":
+  version "0.1.1-beta.8"
+  resolved "https://registry.yarnpkg.com/@rsksmart/ipfs-cpinner-client/-/ipfs-cpinner-client-0.1.1-beta.8.tgz#4c8a3616e347d01ce33cc5812930aaf5b74c1744"
+  integrity sha512-ZIhKpbcIrifUY6EV/yiqcfoPPVlb/mLfiVtkLm2FZDu/QmrJaBsa6PKpofWoXXEAHAYGAvRUtPFD69yY83GMrg==
   dependencies:
-    axios "^0.21.0"
+    axios "^0.21.1"
     buffer "^6.0.3"
     did-jwt "^4.6.2"
     eth-sig-util "^3.0.0"
@@ -3207,7 +3207,7 @@ axios@^0.20.0:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@^0.21.0:
+axios@^0.21.0, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
@@ -5031,6 +5031,13 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
+did-jwt-vc@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/did-jwt-vc/-/did-jwt-vc-1.0.7.tgz#ff25bb14b5b7468576533bd37409aad9bb746745"
+  integrity sha512-ZQypMpR3TovdEc67SEOvhb0h3lnMRgm7PagNVnEO0FiPb4qVC1hMkX/qQd6SQqx8sW5GjYRm3xTWYMXaWDpgwQ==
+  dependencies:
+    did-jwt "^4.8.1"
+
 did-jwt@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-3.0.0.tgz#5e11f1d6e5c9e2d8bdcba0d391f1fcec7c58a07d"
@@ -5046,7 +5053,7 @@ did-jwt@^3.0.0:
     tweetnacl "^1.0.1"
     uport-base64url "3.0.2-alpha.0"
 
-did-jwt@^4.6.2:
+did-jwt@^4.6.2, did-jwt@^4.8.1:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-4.8.1.tgz#fae7d680c6d12c13cdce92530540d9f4b5d007f0"
   integrity sha512-TRfk6He4MSUe3mN+YBqX4wC8N4ns3jan0Ckwal6fPsexKYRwo20ns8w0IGt7J4oHOF3IxXNAkH07OBdEpMnEdA==


### PR DESCRIPTION
## Create Verifiable Presentations

After downloading a credential from their datavault, the user can create a verifiable presentation using their wallet as the signer.

- Uses `did-jwt-vc` for the signing. 
- Displays the raw JWT in a textarea. In the near future, when the decoder app is available, this will change to a link to the recorder. 