### PR TITLE
Add Portis support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:ci": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --format junit --output-file ./reports/eslint.xml"
   },
   "dependencies": {
+    "@portis/web3": "^4.0.0",
     "@reduxjs/toolkit": "^1.4.0",
     "@rsksmart/ethr-did": "^1.1.1-beta.1",
     "@rsksmart/ipfs-cpinner-client": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@reduxjs/toolkit": "^1.4.0",
     "@rsksmart/ethr-did": "^1.1.1-beta.1",
     "@rsksmart/ipfs-cpinner-client": "0.1.2",
-    "@rsksmart/rlogin": "1.0.5",
+    "@rsksmart/rlogin": "1.0.7-beta.1",
     "@rsksmart/rsk-contract-metadata": "^1.0.4",
     "@rsksmart/rsk-testnet-contract-metadata": "^1.0.3",
     "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@reduxjs/toolkit": "^1.4.0",
     "@rsksmart/ethr-did": "^1.1.1-beta.1",
     "@rsksmart/ipfs-cpinner-client": "0.1.2",
-    "@rsksmart/rlogin": "1.0.7-beta.1",
+    "@rsksmart/rlogin": "1.0.8",
     "@rsksmart/rsk-contract-metadata": "^1.0.4",
     "@rsksmart/rsk-testnet-contract-metadata": "^1.0.3",
     "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-identity-manager",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "private": true,
   "homepage": ".",
   "license": "MIT",

--- a/src/app/Identity/IdentityComponent.tsx
+++ b/src/app/Identity/IdentityComponent.tsx
@@ -29,6 +29,14 @@ const IdentityComponent: React.FC<IdentityComponentInterface> = ({
   const handleAddAttribute = (type: string, value: string, validity: number) =>
     addAttribute(context?.provider, type, value, validity)
 
+  if (context?.provider && context?.provider.isPortis) {
+    return (
+      <div className="container">
+        <p className="alert warning">Sorry, you can not modify your identity using Portis. Please use a different wallet such as Metmask, Nifty, or Wallet Connect.</p>
+      </div>
+    )
+  }
+
   return (
     <div className="content identity">
       <div className="container">

--- a/src/app/state/operations/identity.ts
+++ b/src/app/state/operations/identity.ts
@@ -18,8 +18,9 @@ import { reset as resetEthrDid } from '../reducers/ethrdid'
  * @param context the app context where the provider will be ser
  */
 export const login = (context: any) => (dispatch: Dispatch<any>) =>
-  rLogin.connect().then(({ provider }: any) => {
+  rLogin.connect().then(({ provider, disconnect }: any) => {
     context.setProvider(provider)
+    context.setDisconnect(disconnect)
 
     getAccountAndNetwork(provider).then(([address, chainId]) => {
       dispatch(changeAccount({ address }))

--- a/src/features/rLogin.ts
+++ b/src/features/rLogin.ts
@@ -26,7 +26,7 @@ export const rLogin = new RLogin({
       options: {
         id: '26ef5a8d-0226-4e3d-ae69-05707c9a453a',
         network: {
-          nodeUrl: 'https://public-node.testnet.rsk.co',
+          nodeUrl: getRPCUrl(30),
           chainId: 30
         }
       }

--- a/src/features/rLogin.ts
+++ b/src/features/rLogin.ts
@@ -1,5 +1,6 @@
 import RLogin from '@rsksmart/rlogin'
 import WalletConnectProvider from '@walletconnect/web3-provider'
+import Portis from '@portis/web3'
 import { getRPCUrl } from '../config/getConfig'
 
 export const rLogin = new RLogin({
@@ -17,6 +18,16 @@ export const rLogin = new RLogin({
           31: getRPCUrl(31),
           42: getRPCUrl(42),
           5777: getRPCUrl(5777)
+        }
+      }
+    },
+    portis: {
+      package: Portis,
+      options: {
+        id: '26ef5a8d-0226-4e3d-ae69-05707c9a453a',
+        network: {
+          nodeUrl: 'https://public-node.testnet.rsk.co',
+          chainId: 30
         }
       }
     }

--- a/src/features/rLogin.ts
+++ b/src/features/rLogin.ts
@@ -26,8 +26,8 @@ export const rLogin = new RLogin({
       options: {
         id: '26ef5a8d-0226-4e3d-ae69-05707c9a453a',
         network: {
-          nodeUrl: getRPCUrl(30),
-          chainId: 30
+          nodeUrl: getRPCUrl(31),
+          chainId: 31
         }
       }
     }

--- a/src/providerContext.tsx
+++ b/src/providerContext.tsx
@@ -6,6 +6,7 @@ export interface Web3ProviderContextInterface {
   setProvider?: (value: any) => void
   dvClient: DataVaultWebClient | null,
   setDvClient?: (client: DataVaultWebClient) => void
+  setDisconnect?: (disconnect: any) => void
   reset: () => void
 }
 
@@ -22,15 +23,18 @@ interface Web3ProviderElementInterface {
 export const Web3ProviderElement: React.FC<Web3ProviderElementInterface> = ({ children }) => {
   const [provider, setProvider] = useState<any | null>(null)
   const [dvClient, setDvClient] = useState<DataVaultWebClient | null>(null)
+  const [disconnectMethod, setDisconnectMethod] = useState<any | null>(null)
 
   const initialContext: Web3ProviderContextInterface = {
     provider: provider,
     setProvider: (provider: any) => setProvider(provider),
     dvClient: dvClient,
     setDvClient: (client: DataVaultWebClient | null) => setDvClient(client),
+    setDisconnect: (disFunction: any) => setDisconnectMethod(() => disFunction),
     reset: () => {
       setProvider(null)
       setDvClient(null)
+      disconnectMethod && disconnectMethod().catch(console.log)
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,6 +1844,16 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@portis/web3@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@portis/web3/-/web3-4.0.0.tgz#4329f5eb6aac0924b23629ba06972f53c758fa4a"
+  integrity sha512-WAoqpmIuyR/k5U4X1P85HM6OyQJgHpaHy9LCcXGRecIQosl7BwZSOLcWVd3aepvM37o1Q9li/ad3F/Tdmd1mhg==
+  dependencies:
+    ethereumjs-util "5.2.0"
+    penpal "3.0.7"
+    pocket-js-core "0.0.3"
+    web3-provider-engine "16.0.1"
+
 "@reduxjs/toolkit@^1.4.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.5.0.tgz#1025c1ccb224d1fc06d8d98a61f6717d57e6d477"
@@ -3541,6 +3551,14 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.2.tgz#7cf783331320098bfbef620df3b3c770147bc224"
   integrity sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==
 
+axios@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 axios@^0.21.0, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -3847,6 +3865,13 @@ bindings@^1.2.1, bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bip66@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"
+  integrity sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=
+  dependencies:
+    safe-buffer "^5.0.1"
+
 blakejs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
@@ -3958,7 +3983,7 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.2.0:
+browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.0.6, browserify-aes@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
@@ -5218,6 +5243,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.1, debug@^3.2.5:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -5639,6 +5671,15 @@ dotenv@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
+drbg.js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"
+  integrity sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=
+  dependencies:
+    browserify-aes "^1.0.6"
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
 
 duplexer@^0.1.1:
   version "0.1.2"
@@ -6455,6 +6496,19 @@ ethereumjs-util@*, ethereumjs-util@^7.0.7:
     ethjs-util "0.1.6"
     rlp "^2.2.4"
 
+ethereumjs-util@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz#3e0c0d1741471acf1036052d048623dee54ad642"
+  integrity sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "^0.1.3"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
 ethereumjs-util@^5.0.0, ethereumjs-util@^5.1.1, ethereumjs-util@^5.1.2, ethereumjs-util@^5.1.5:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz#a833f0e5fca7e5b361384dc76301a721f537bf65"
@@ -7041,6 +7095,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.2"
@@ -8007,6 +8068,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.2:
   version "1.2.3"
@@ -9820,7 +9886,7 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.2.1:
+nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.2.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
@@ -10624,6 +10690,11 @@ pbkdf2@^3.0.17, pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+penpal@3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/penpal/-/penpal-3.0.7.tgz#d252711ed93b30f1d867eb82342785b3a95f5f75"
+  integrity sha512-WSXiq5HnEvzvY05SHhaXcsviUmCvh4Ze8AiIZzvmdzaaYAAx4rx8c6Xq6+MaVDG/Nfve3VmGD8HyRP3CkPvPbQ==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -10712,6 +10783,13 @@ pnp-webpack-plugin@1.6.4:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+pocket-js-core@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/pocket-js-core/-/pocket-js-core-0.0.3.tgz#1ab278b9a6a5775e2bdc3c2c2e218057774061e4"
+  integrity sha512-OUTEvEVutdjLT6YyldvAlSebpBueUUWg2XKxGNt5u3QqrmLpBOOBmdDnGMNJ+lEwXtko+JqgwFq+HTi4g1QDVg==
+  dependencies:
+    axios "^0.18.0"
 
 portfinder@^1.0.26:
   version "1.0.28"
@@ -12595,6 +12673,20 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+secp256k1@^3.0.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.8.0.tgz#28f59f4b01dbee9575f56a47034b7d2e3b3b352d"
+  integrity sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==
+  dependencies:
+    bindings "^1.5.0"
+    bip66 "^1.1.5"
+    bn.js "^4.11.8"
+    create-hash "^1.2.0"
+    drbg.js "^1.0.1"
+    elliptic "^6.5.2"
+    nan "^2.14.0"
+    safe-buffer "^5.1.2"
 
 secp256k1@^4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,17 +1906,6 @@
     ethjs-query "^0.3.8"
     ethr-did-resolver "^1.0.2"
 
-"@rsksmart/ipfs-cpinner-client@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@rsksmart/ipfs-cpinner-client/-/ipfs-cpinner-client-0.1.1.tgz#f67ad2420ca200e0de0c1eb1029c93e20760dcd7"
-  integrity sha512-XX/K7+pV10IumvYJWbI/bw6qVeFkWkPej2ipBw6k5NTDPZdgLpX5Uz2Jt9shQHbrR3JuenhXDLazwnaVoL4sow==
-  dependencies:
-    axios "^0.21.1"
-    buffer "^6.0.3"
-    crypto-js "^4.0.0"
-    did-jwt "^4.6.2"
-    eth-sig-util "^3.0.0"
-
 "@rsksmart/ipfs-cpinner-client@0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@rsksmart/ipfs-cpinner-client/-/ipfs-cpinner-client-0.1.2.tgz#bc4a5f3ef6dab78e7defa04f30f905187f698783"
@@ -1928,12 +1917,12 @@
     did-jwt "^4.6.2"
     eth-sig-util "^3.0.0"
 
-"@rsksmart/rlogin@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@rsksmart/rlogin/-/rlogin-1.0.5.tgz#cdcc974fbf9a47b9c06d4d0a37ec7ddb9be6c27e"
-  integrity sha512-oB4VeZfmX1AaUNvEJHZHPiv0YuEATLjQeOD38+McKp3jj9iGjVzxPmc8OMbeD2BZS7okQOEAOMvfjEggoW1rjQ==
+"@rsksmart/rlogin@1.0.7-beta.1":
+  version "1.0.7-beta.1"
+  resolved "https://registry.yarnpkg.com/@rsksmart/rlogin/-/rlogin-1.0.7-beta.1.tgz#bc79ccbcbce961538669980d70e30614f201cc14"
+  integrity sha512-X1YBPwIs5LHIn5nzbnawlt/bJ0YBx2MWvNC74gvXUeDBhRtN33FzYWihIPG0lhyNY01xVPZ8wKQTlwj1UEFXdQ==
   dependencies:
-    "@rsksmart/ipfs-cpinner-client" "0.1.1"
+    "@rsksmart/ipfs-cpinner-client" "0.1.2"
     "@rsksmart/vc-json-schemas-parser" "^1.0.0"
     "@types/styled-components" "^5.1.3"
     axios "^0.21.1"
@@ -6417,15 +6406,7 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
-ethereumjs-abi@^0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
-  integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
-  dependencies:
-    bn.js "^4.11.8"
-    ethereumjs-util "^6.0.0"
-
-"ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,10 +1917,10 @@
     did-jwt "^4.6.2"
     eth-sig-util "^3.0.0"
 
-"@rsksmart/rlogin@1.0.7-beta.1":
-  version "1.0.7-beta.1"
-  resolved "https://registry.yarnpkg.com/@rsksmart/rlogin/-/rlogin-1.0.7-beta.1.tgz#bc79ccbcbce961538669980d70e30614f201cc14"
-  integrity sha512-X1YBPwIs5LHIn5nzbnawlt/bJ0YBx2MWvNC74gvXUeDBhRtN33FzYWihIPG0lhyNY01xVPZ8wKQTlwj1UEFXdQ==
+"@rsksmart/rlogin@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@rsksmart/rlogin/-/rlogin-1.0.8.tgz#b5c1761808ff52b7ffbd64696e31641a61cbddb9"
+  integrity sha512-qAHliJzLX0EcbquVeg1SChu0YQYQm9XhFZ8UCU2RHP1onc/Tt7JtMbVEiO36ft9ULRY/uiw4Ud6AGdY6Od5kyQ==
   dependencies:
     "@rsksmart/ipfs-cpinner-client" "0.1.2"
     "@rsksmart/vc-json-schemas-parser" "^1.0.0"


### PR DESCRIPTION
Pending release of the next version of rLogin.

- Adds Portis as a web3 provider. 
- Also, when the provider is not metamask, the DataVault content will be decrypted onLoad since the `SignerEncryptionManager` does not need interaction from the user's wallet to decrypt content. 
- The Identity screen has been disabled for Portis because Ethrdid uses the older `sendAsync` command, and Portis does not estimate the gas correctly. 
