### PR TITLE
Add Plausible analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,5 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script async defer data-domain="identity.rifos.org" src="https://plausible.io/js/plausible.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -17,5 +17,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script async defer data-domain="identity.rifos.org" src="https://plausible.io/js/plausible.js"></script>
   </body>
 </html>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,7 @@ import LoginScreenContainer from './Login/LoginScreenContainer'
 import AuthenticatedContainer from './Authenticated/AuthenticatedContainer'
 import RifFooter from '../components/RifFooter/RifFooter'
 import { Web3ProviderContext } from '../providerContext'
+import PlausibleAnalytics from '../components/Plausible/PlausibleAnalytics'
 
 const App = () => {
   const context = useContext(Web3ProviderContext)
@@ -17,6 +18,7 @@ const App = () => {
         : <LoginScreenContainer context={context} />
       }
       <RifFooter isLoggedIn={isLoggedIn} version={version} />
+      <PlausibleAnalytics domain="identity.rifos.org" />
     </div>
   )
 }

--- a/src/assets/scss/_index.scss
+++ b/src/assets/scss/_index.scss
@@ -34,6 +34,7 @@ html, body {
 @import 'components/navigation';
 @import 'components/panel';
 @import 'components/balance-row';
+@import 'components/plausible';
 
 @import 'screens/login-screen';
 @import 'screens/dashboard';

--- a/src/assets/scss/components/_plausible.scss
+++ b/src/assets/scss/components/_plausible.scss
@@ -1,0 +1,29 @@
+#analytics {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  padding: 15px 0;
+  text-align: center;
+  background-color: rgba(0, 143, 247, .6);
+
+  p {
+    width: 85%;
+    margin: 3px auto;
+    font-size: 75%;
+  }
+
+  button {
+    border: 1px solid $blue;
+    background: none;
+    padding: 5px 10px;
+    margin: 5px 10px 0 10px;
+  }
+
+  button.accept {
+    background-color: $white;
+  }
+
+  button:hover {
+    opacity: .8;
+  }
+}

--- a/src/components/Plausible/PlausibleAnalytics.test.tsx
+++ b/src/components/Plausible/PlausibleAnalytics.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import PlausibleAnalytics from './PlausibleAnalytics'
+
+describe('Component: PlausibleAnalytics', () => {
+  const sharedProps = { domain: 'identity.rifos.org' }
+
+  it('renders the component showing the content', () => {
+    const wrapper = mount(<PlausibleAnalytics {...sharedProps} />)
+    expect(wrapper).toBeDefined()
+
+    expect(wrapper.find('#analytics')).toHaveLength(1)
+    expect(wrapper.find('button')).toHaveLength(2)
+  })
+
+  it('hides the content if user has already specified', () => {
+    localStorage.setItem('PLAUSIBLE_ID_MANAGER', 'GRANTED')
+
+    const wrapperAccepted = mount(<PlausibleAnalytics {...sharedProps} />)
+    expect(wrapperAccepted.find('#analytics')).toMatchObject({})
+
+    localStorage.setItem('PLAUSIBLE_ID_MANAGER', 'DENIED')
+    const wrapperDenied = mount(<PlausibleAnalytics {...sharedProps} />)
+    expect(wrapperDenied.find('#analytics')).toMatchObject({})
+  })
+})

--- a/src/components/Plausible/PlausibleAnalytics.tsx
+++ b/src/components/Plausible/PlausibleAnalytics.tsx
@@ -1,35 +1,61 @@
-import React, { useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
+
+// eslint-disable-next-line no-unused-vars
+export enum Decision { DENIED = 'DENIED', GRANTED = 'GRANTED', DEFAULT = 'DEFAULT' }
+
+const APP_NAME = 'ID_MANAGER'
 
 interface Interface {
   domain: string,
 }
 
-const PlausibleAnalytics: React.FC<Interface> = () => {
+const PlausibleAnalytics: React.FC<Interface> = ({ domain }) => {
+  const [show, setShow] = useState<boolean>(false)
+
   const linkProps = {
     target: '_blank',
     rel: 'noopener'
   }
 
-  const handleClick = (props: any) => {
-    console.log('handling click...', props)
-  }
-
   useEffect(() => {
-    console.log('Plausible useEffect!')
+    const answer = localStorage.getItem(`PLAUSIBLE_${APP_NAME}`) || Decision.DEFAULT
+
+    setShow(answer === Decision.DEFAULT)
+    if (answer === Decision.GRANTED) {
+      addAnalyticsScript()
+    }
   }, [])
 
-  return (
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    const decision = event.currentTarget.id === 'accept' ? Decision.GRANTED : Decision.DENIED
+    localStorage.setItem(`PLAUSIBLE_${APP_NAME}`, decision)
+
+    setShow(false)
+    if (decision === Decision.GRANTED) {
+      addAnalyticsScript()
+    }
+  }
+
+  const addAnalyticsScript = () => {
+    const script = document.createElement('script')
+    script.setAttribute('src', 'https://plausible.io/js/plausible.js')
+    script.setAttribute('async', 'true')
+    script.setAttribute('data-domain', domain)
+    document.head.appendChild(script)
+  }
+
+  return show ? (
     <div id="analytics">
       <p>In order to improve the user&apos;s experience, this site uses Plausible, an open source and privacy-friendly tool, which does not use cookies and is compliant with GDPR, CCPA and PECR. We analyse your activity and our traffic. We strive to collect only the data that we need. We do not share your information with third parties; we want to better understand your behaviour in order to improve our website. Please take a moment to familiarize yourself with <a href="https://plausible.io/data-policy" {...linkProps}>Plausible’s</a> and <a href="https://www.rsk.co/privacy-policy" {...linkProps}>our policies</a>.</p>
       <p>If you accept Plausible’s and ours policy, please click Accept.</p>
       <p>If you do not accept Plausible’s and ours policy, we provide you with the means to disable our tracking system, please click Reject.</p>
       <p>Certain features of the site may not be available if the tracking system is disabled.*</p>
       <p>
-        <button onClick={handleClick} className="accept">Accept</button>
-        <button onClick={handleClick} className="reject">Reject</button>
+        <button onClick={handleClick} id="accept">Accept</button>
+        <button onClick={handleClick} id="reject">Reject</button>
       </p>
     </div>
-  )
+  ) : <></>
 }
 
 export default PlausibleAnalytics

--- a/src/components/Plausible/PlausibleAnalytics.tsx
+++ b/src/components/Plausible/PlausibleAnalytics.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react'
+
+interface Interface {
+  domain: string,
+}
+
+const PlausibleAnalytics: React.FC<Interface> = () => {
+  const linkProps = {
+    target: '_blank',
+    rel: 'noopener'
+  }
+
+  const handleClick = (props: any) => {
+    console.log('handling click...', props)
+  }
+
+  useEffect(() => {
+    console.log('Plausible useEffect!')
+  }, [])
+
+  return (
+    <div id="analytics">
+      <p>In order to improve the user&apos;s experience, this site uses Plausible, an open source and privacy-friendly tool, which does not use cookies and is compliant with GDPR, CCPA and PECR. We analyse your activity and our traffic. We strive to collect only the data that we need. We do not share your information with third parties; we want to better understand your behaviour in order to improve our website. Please take a moment to familiarize yourself with <a href="https://plausible.io/data-policy" {...linkProps}>Plausible’s</a> and <a href="https://www.rsk.co/privacy-policy" {...linkProps}>our policies</a>.</p>
+      <p>If you accept Plausible’s and ours policy, please click Accept.</p>
+      <p>If you do not accept Plausible’s and ours policy, we provide you with the means to disable our tracking system, please click Reject.</p>
+      <p>Certain features of the site may not be available if the tracking system is disabled.*</p>
+      <p>
+        <button onClick={handleClick} className="accept">Accept</button>
+        <button onClick={handleClick} className="reject">Reject</button>
+      </p>
+    </div>
+  )
+}
+
+export default PlausibleAnalytics

--- a/src/components/RifFooter/RifFooter.test.tsx
+++ b/src/components/RifFooter/RifFooter.test.tsx
@@ -12,7 +12,7 @@ describe('Component: Rif Footer', () => {
     const wrapper = shallow(<RifFooter isLoggedIn version="0.0.1" />)
 
     expect(wrapper.find('img').props().src).toBe('powered-by-iov-gray.svg')
-    expect(wrapper.find('p').at(0).text()).toBe('Copyright © 2020 IOV Labs. All rights reserved.')
+    expect(wrapper.find('p').at(0).text()).toBe('Copyright © 2021 IOV Labs. All rights reserved.')
   })
 
   it('loads white footer image when not logged in', () => {

--- a/src/components/RifFooter/RifFooter.tsx
+++ b/src/components/RifFooter/RifFooter.tsx
@@ -10,7 +10,7 @@ interface RifFooterInterface {
 const RifFooter: React.FC<RifFooterInterface> = ({ isLoggedIn, version }) => (
   <footer className="app-footer">
     <img src={isLoggedIn ? poweredGray : powered} alt="Powered By IOV" />
-    <p>Copyright &copy; 2020 IOV Labs. All rights reserved.</p>
+    <p>Copyright &copy; 2021 IOV Labs. All rights reserved.</p>
     <p>Version {version}</p>
   </footer>
 )


### PR DESCRIPTION
Adds Plausible analytics to the RIF Id Manager. Since it does not work while using localhost, you have to test it with

The initial start shows a message at the bottom asking permission to track. If the user responds, it is saved in localStorage. If granted, the plausible js script is loaded to into the site. 

* [GH Pages Deployment](https://rsksmart.github.io/rif-identity-manager/) - for testing
* [Public Analytics](https://plausible.io/identity.rifos.org) - this can be set to private in the future