### PR TITLE
Plusible requested changes from Milton

### DIFF
--- a/src/assets/scss/components/_plausible.scss
+++ b/src/assets/scss/components/_plausible.scss
@@ -8,19 +8,27 @@
 
   p {
     width: 85%;
+    max-width: 750px;
     margin: 3px auto;
-    font-size: 75%;
+    font-size: 85%;
+    line-height: 1.25em;
   }
 
   button {
-    border: 1px solid $blue;
     background: none;
+    border: none;
     padding: 5px 10px;
     margin: 5px 10px 0 10px;
   }
 
-  button.accept {
-    background-color: $white;
+  button#accept {
+    background-color: $blue;
+    color: #fff;
+  }
+
+  button#reject {
+    background-color: #e1e1e1;
+    color: #666;
   }
 
   button:hover {


### PR DESCRIPTION
Changes to the style/design of the plausible popup.

What changed:

* Added colors to the buttons
* Increased the font-size and line-height
* Decreased the margins to make the readable line "smaller" on larger devices.

This is [published on GH pages](https://rsksmart.github.io/rif-identity-manager/), however, I bet it will be overwritten by the next PR, so here is a screenshot of the changes:

## Before
![Screen Shot 2021-05-24 at 2 27 33 PM](https://user-images.githubusercontent.com/766679/119341254-367cca00-bc9c-11eb-9ed1-80d923a4c20f.png)

### After
![Screen Shot 2021-05-24 at 2 25 07 PM](https://user-images.githubusercontent.com/766679/119341035-fe758700-bc9b-11eb-9638-d114af456e02.png)
